### PR TITLE
Add chown step

### DIFF
--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -41,7 +41,7 @@ spec:
     - "--provider"
     - "aws"
     - "--endpoint"
-    - "https://api.g8s.gaia.eu-central-1.aws.gigantic.io"
+    - "http://api-service.giantswarm.svc.cluster.local:8000"
     - "--releases"
     - "/workspace/releases"
     - "--output"


### PR DESCRIPTION
This PR adds a step to `create-cluster` so that `/workspace/releases` can be written to by `giantswarm` user (1000).

I'm also reverting the API URL to the public one because the internal one was causing problems.