### PR TITLE
Adjust timeouts

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -26,7 +26,7 @@ presubmits:
       pipelineRef:
         name: cis
       serviceAccountName: test-runs
-      timeout: 2h0m0s
+      timeout: 5h0m0s
       resources:
       - name: releases
         resourceRef:
@@ -51,7 +51,7 @@ presubmits:
       pipelineRef:
         name: cncf
       serviceAccountName: test-runs
-      timeout: 5h0m0s
+      timeout: 10h0m0s
       resources:
       - name: releases
         resourceRef:

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -26,6 +26,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
+    timeout: 2h0m0s
     taskRef:
       name: wait-for-ready
     workspaces:

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -26,7 +26,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 2h0m0s
+    timeout: 1h0m0s
     taskRef:
       name: wait-for-ready
     workspaces:

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -26,6 +26,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
+    timeout: 2h0m0s
     taskRef:
       name: wait-for-ready
     workspaces:

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -26,7 +26,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 2h0m0s
+    timeout: 1h0m0s
     taskRef:
       name: wait-for-ready
     workspaces:


### PR DESCRIPTION
Pipeline timeouts should be bigger than the sum of tasks timeouts (where we have them) so that we hit tasks timeouts first. Right now if cncf takes more than 5h the whole pipeline gets killed and cleanup never happens. 