### PR TITLE
App testing hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ and policy to enable access to it. Don't forget to update the `s3-bucket-credent
 
 ## More documentation
 
-
 More documentation can be found in the [`docs`](https://github.com/giantswarm/test-infra/tree/master/docs) directory of this repository.
-
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Templates for these secrets can be found in the `secrets` folder.
 If you don't have an existing S3 bucket to store the test results, switch your [role](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/aws-role-switching/#aws-cli) if needed and run [this](scripts/s3-bucket-access.sh) script. It will create a bucket and also IAM role
 and policy to enable access to it. Don't forget to update the `s3-bucket-credentials` secret with the generated credentials.
 
-
 ## More documentation
 
 More documentation can be found in the [`docs`](https://github.com/giantswarm/test-infra/tree/master/docs) directory of this repository.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Templates for these secrets can be found in the `secrets` folder.
 If you don't have an existing S3 bucket to store the test results, switch your [role](https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/aws-role-switching/#aws-cli) if needed and run [this](scripts/s3-bucket-access.sh) script. It will create a bucket and also IAM role
 and policy to enable access to it. Don't forget to update the `s3-bucket-credentials` secret with the generated credentials.
 
+
+## More documentation
+
+
+More documentation can be found in the [`docs`](https://github.com/giantswarm/test-infra/tree/master/docs) directory of this repository.
+
+
 ## Reference
 
 * How to write [`ProwJobs`](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md)

--- a/docs/create-prow-command.md
+++ b/docs/create-prow-command.md
@@ -15,7 +15,7 @@ An example of a configuration:
     max_concurrency: 3 # Number of jobs running concurrently at max.
     always_run: false # If this should run on every commit.
     skip_report: false # If the bot should report in the PR.
-    pipeline_run_spec:
+    pipeline_run_spec: # This is the spec of a tekton PipelineRun CR https://tekton.dev/docs/pipelines/pipelineruns/
       pipelineRef:
         name: cis # Name of the Tekton pipeline. In this case the pipeline is in tekton/pipelines/cis.yaml
       serviceAccountName: releases # Should always be releases.

--- a/docs/create-tekton-pipeline.md
+++ b/docs/create-tekton-pipeline.md
@@ -6,7 +6,8 @@ the flow of task executions uniform across different pipelines.
 Pipelines should reuse tasks for cluster creation and cleanup and
 follow conventions for workspaces and naming.
 
-All pipelines have to be in the `tekton/pipelines` folder.
+All pipelines have to be in the `tekton/pipelines` folder and should be
+registered in `tekton/pipelines/kustomization.yaml`.
 
 You can discover the upstream docs on Tekton pipelines here:
 https://tekton.dev/docs/pipelines/pipelines/

--- a/docs/create-tekton-task.md
+++ b/docs/create-tekton-task.md
@@ -6,7 +6,8 @@ which are supplied either from upstream or internal teams.
 This is where you can check the created cluster for conformity
 and get the different `kubeconfig` for example as inputs.
 
-All tasks have to be in the `tekton/tasks` folder.
+All tasks have to be in the `tekton/tasks` folder and should be
+registered in `tekton/tasks/kustomization.yaml`.
 
 You can discover the upstream docs on Tekton tasks here:
 https://tekton.dev/docs/pipelines/tasks/

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -29,6 +29,9 @@ presubmits:
       - name: app-repository
         resourceRef:
           name: PROW_IMPLICIT_GIT_REF
+      - name: releases
+        resourceRef:
+          name: releases-master
       workspaces:
       - name: cluster
         volumeClaimTemplate:
@@ -38,13 +41,6 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-      # TODO remove this once standup is used for cluster creation
-      - name: tenant-kubeconfig
-        secret:
-          secretName: tenant-kubeconfig
-          items:
-          - key: kubeconfig
-            path: kubeconfig
     trigger: "/test this"
     rerun_command: "/test this"
   giantswarm/releases:

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -16,6 +16,37 @@ deck:
       url_template: {{`'http://log-aggregator:8000/logs/{{.ObjectMeta.Name}}'`}}
 
 presubmits:
+  giantswarm/giantswarm-todo-app:
+  - name: test-app
+    agent: tekton-pipeline
+    max_concurrency: 1
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: test-app
+      resources:
+      - name: app-repository
+        resourceRef:
+          name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+      - name: cluster
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10Mi
+      # TODO remove this once standup is used for cluster creation
+      - name: tenant-kubeconfig
+        secret:
+          secretName: tenant-kubeconfig
+          items:
+          - key: kubeconfig
+            path: kubeconfig
+    trigger: "/test this"
+    rerun_command: "/test this"
   giantswarm/releases:
   - name: cis
     agent: tekton-pipeline

--- a/tekton/pipelines/kustomization.yaml
+++ b/tekton/pipelines/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - aws.yaml
 - cis.yaml
 - cncf.yaml
+- pipelineresources.yaml
 - test-app.yaml

--- a/tekton/pipelines/kustomization.yaml
+++ b/tekton/pipelines/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - aws.yaml
 - cis.yaml
 - cncf.yaml
+- test-app.yaml

--- a/tekton/pipelines/pipelineresources.yaml
+++ b/tekton/pipelines/pipelineresources.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: releases-master
+  namespace: test-workloads
+spec:
+  type: git
+  params:
+    - name: url
+      value: https://github.com/giantswarm/releases.git
+    - name: revision
+      value: master

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-app
+  namespace: test-workloads
+spec:
+  resources:
+  - name: app-repository
+    type: git
+  workspaces:
+  - name: cluster
+  - name: cluster2
+  tasks:
+  #- name: create-cluster
+  #  taskRef:
+  #    name: create-cluster
+  #  workspaces:
+  #  - name: cluster
+  #    workspace: cluster
+  #  resources:
+  #    inputs:
+  #    - name: releases
+  #      resource: releases
+
+  - name: wait-for-ready
+    # runAfter: [create-cluster]
+    timeout: 1h0m0s
+    taskRef:
+      name: wait-for-ready
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: prepare-cluster
+    runAfter: [wait-for-ready]
+    taskRef:
+      name: app-test-preparation
+    workspaces:
+    - name: cluster
+      workspace: cluster
+
+  - name: test-app
+    runAfter: [prepare-cluster]
+    taskRef:
+      name: test-app
+    resources:
+      inputs:
+      - name: app-repository
+        resource: app-repository
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    - name: cluster2
+      workspace: cluster2
+
+  #finally:
+  #- name: cleanup
+  #  taskRef:
+  #    name: cleanup
+  #  workspaces:
+  #  - name: cluster
+  #    workspace: cluster

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -7,9 +7,10 @@ spec:
   resources:
   - name: app-repository
     type: git
+  # TODO: add releases repository resource once standup is used for cluster creation
   workspaces:
   - name: cluster
-  - name: cluster2
+  - name: tenant-kubeconfig # TODO remove this once standup is used for cluster creation
   tasks:
   #- name: create-cluster
   #  taskRef:
@@ -28,8 +29,8 @@ spec:
     taskRef:
       name: wait-for-ready
     workspaces:
-      - name: cluster
-        workspace: cluster
+    - name: cluster
+      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
 
   - name: prepare-cluster
     runAfter: [wait-for-ready]
@@ -37,7 +38,7 @@ spec:
       name: app-test-preparation
     workspaces:
     - name: cluster
-      workspace: cluster
+      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
 
   - name: test-app
     runAfter: [prepare-cluster]
@@ -50,8 +51,9 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
-    - name: cluster2
-      workspace: cluster2
+    # TODO remove this once standup is used for cluster creation
+    - name: tenant-kubeconfig
+      workspace: tenant-kubeconfig
 
   #finally:
   #- name: cleanup

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -7,30 +7,35 @@ spec:
   resources:
   - name: app-repository
     type: git
-  # TODO: add releases repository resource once standup is used for cluster creation
+  - name: releases
+    type: git
   workspaces:
   - name: cluster
-  - name: tenant-kubeconfig # TODO remove this once standup is used for cluster creation
   tasks:
-  #- name: create-cluster
-  #  taskRef:
-  #    name: create-cluster
-  #  workspaces:
-  #  - name: cluster
-  #    workspace: cluster
-  #  resources:
-  #    inputs:
-  #    - name: releases
-  #      resource: releases
+  - name: create-cluster
+    taskRef:
+      name: create-cluster
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    params:
+    - name: create-extra-args
+      value:
+        - "--provider aws"
+        - "--release v12.3.0"
+    resources:
+      inputs:
+      - name: releases
+        resource: releases
 
   - name: wait-for-ready
-    # runAfter: [create-cluster]
+    runAfter: [create-cluster]
     timeout: 1h0m0s
     taskRef:
       name: wait-for-ready
     workspaces:
     - name: cluster
-      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
+      workspace: cluster
 
   - name: prepare-cluster
     runAfter: [wait-for-ready]
@@ -38,7 +43,7 @@ spec:
       name: app-test-preparation
     workspaces:
     - name: cluster
-      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
+      workspace: cluster
 
   - name: test-app
     runAfter: [prepare-cluster]
@@ -51,14 +56,11 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
-    # TODO remove this once standup is used for cluster creation
-    - name: tenant-kubeconfig
-      workspace: tenant-kubeconfig
 
-  #finally:
-  #- name: cleanup
-  #  taskRef:
-  #    name: cleanup
-  #  workspaces:
-  #  - name: cluster
-  #    workspace: cluster
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+    - name: cluster
+      workspace: cluster

--- a/tekton/tasks/app-test-preparation.yaml
+++ b/tekton/tasks/app-test-preparation.yaml
@@ -10,6 +10,7 @@ spec:
   steps:
   - name: prepare-cluster
     image: quay.io/geraldpape/atc # TODO use official image
+    imagePullPolicy: Always
     script: |
       #!/bin/sh
       apptestctl bootstrap --kubeconfig "$(cat $(workspaces.cluster.path)/kubeconfig)"

--- a/tekton/tasks/app-test-preparation.yaml
+++ b/tekton/tasks/app-test-preparation.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: app-test-preparation
+  namespace: test-workloads
+spec:
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  steps:
+  - name: prepare-cluster
+    image: quay.io/geraldpape/atc # TODO use official image
+    script: |
+      #!/bin/sh
+      apptestctl bootstrap --kubeconfig "$(cat $(workspaces.cluster.path)/kubeconfig)"

--- a/tekton/tasks/app-test-preparation.yaml
+++ b/tekton/tasks/app-test-preparation.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: prepare-cluster
-    image: quay.io/giantswarm/apptestctl:0.3.1-de5ceccf8a8e08b75af0d6d0a65600d1b21e9036
+    image: quay.io/giantswarm/apptestctl:0.3.1-d3d18b309405ad460e77e230560b7854672a88a4
     script: |
       #!/bin/sh
       apptestctl bootstrap --kubeconfig "$(cat $(workspaces.cluster.path)/kubeconfig)"

--- a/tekton/tasks/app-test-preparation.yaml
+++ b/tekton/tasks/app-test-preparation.yaml
@@ -9,8 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: prepare-cluster
-    image: quay.io/geraldpape/atc # TODO use official image
-    imagePullPolicy: Always
+    image: quay.io/giantswarm/apptestctl:0.3.1-de5ceccf8a8e08b75af0d6d0a65600d1b21e9036
     script: |
       #!/bin/sh
       apptestctl bootstrap --kubeconfig "$(cat $(workspaces.cluster.path)/kubeconfig)"

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -4,6 +4,10 @@ metadata:
   name: create-cluster
   namespace: test-workloads
 spec:
+  params:
+  - name: create-extra-args
+    type: array
+    description: Extra args to pass to the create command
   resources:
     inputs:
     - name: releases
@@ -36,10 +40,11 @@ spec:
         mountPath: /etc/endpoints-config
       - name: kubeconfig
         mountPath: /etc/kubeconfig
-    script: |
-      #! /bin/sh
-      standup create \
-      --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig/kubeconfig \
-      --releases /workspace/releases \
-      --output $(workspaces.cluster.path)
+    args: [
+      "create",
+      "--config", "/etc/endpoints-config/config",
+      "--kubeconfig", "/etc/kubeconfig/kubeconfig",
+      "--releases", "/workspace/releases",
+      "--output", "$(workspaces.cluster.path)",
+      "$(params.create-extra-args[*])"
+    ]

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- app-test-preparation.yaml
 - aws.yaml
 - cis.yaml
 - cleanup.yaml
 - cncf.yaml
 - create-cluster.yaml
+- test-app.yaml
 - upload-to-s3-bucket.yaml
 - wait-for-ready.yaml

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test-app
+  namespace: test-workloads
+spec:
+  resources:
+    inputs:
+    - name: app-repository
+      type: git
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  - name: cluster2
+    description: The original cluster workspace.
+  steps:
+  - name: app-build-suite
+    image: quay.io/geraldpape/abs # TODO use official image
+    imagePullPolicy: Always
+    script: |
+      #!/bin/sh
+
+      CHART_DIR=$(find $(resources.inputs.app-repository.path)/helm -maxdepth 1 -type d -name "*-app")
+      CHART_NAME=${CHART_DIR##*/}
+
+      echo "${CHART_DIR}"
+      echo "${CHART_NAME}"
+
+      cd $(workspaces.cluster2.path) # TODO check if app_build_suite supports an --output flag
+
+      python -m app_build_suite \
+        --chart-dir "${CHART_DIR}" \
+        --replace-chart-version-with-git \
+        --replace-app-version-with-git
+
+      PACKAGE_PATH=$(find $(workspaces.cluster2.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
+      echo "${PACKAGE_PATH}"
+
+#  - name: upload-chart
+#    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
+#    script: |
+#      #!/bin/sh
+#
+#      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chart-museum 8080:8080 &
+#      KUBECTL_PID=$!
+#      sleep 5
+#
+#      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
+#
+#      kill $KUBECTL_PID
+#
+#
+#  - name: pytest
+#    image: python:3.7-slim
+#    script: |
+#      #!/bin/sh
+#
+#      pip install pipenv
+#
+#      cd /workspace/app-repository/test/kat
+#      pipenv sync
+#      pipenv run pytest --log-cli-level info --full-trace --verbosity=8 . \
+#      --cluster-type existing \
+#      --kube-config /kube.config \
+#      --values-file ../../${config_file} \
+#      --chart-path \"helm/${chart_name}\" \
+#      --chart-version ${CHART_VERSION} \
+#      --log-cli-level info \
+#      --junitxml=../../${test_res_file}"

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -11,8 +11,9 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
-  - name: cluster2
-    description: The original cluster workspace.
+  # TODO remove this once standup is used for cluster creation
+  - name: tenant-kubeconfig
+    description: Holds kubeconfig of the tenant cluster
   steps:
   - name: app-build-suite
     image: quay.io/geraldpape/abs # TODO use official image
@@ -26,14 +27,14 @@ spec:
       echo "${CHART_DIR}"
       echo "${CHART_NAME}"
 
-      cd $(workspaces.cluster2.path) # TODO check if app_build_suite supports an --output flag
+      cd $(workspaces.cluster.path) # TODO check if app_build_suite supports an --output flag
 
       python -m app_build_suite \
         --chart-dir "${CHART_DIR}" \
         --replace-chart-version-with-git \
         --replace-app-version-with-git
 
-      PACKAGE_PATH=$(find $(workspaces.cluster2.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
+      PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
       echo "${PACKAGE_PATH}"
 
 #  - name: upload-chart

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -47,10 +47,41 @@ spec:
       echo "${CHART_NAME}"
       echo "${PACKAGE_PATH}"
 
-      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chartmuseum-chartmuseum 8080:8080 &
+      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig -n giantswarm wait --for=condition=Ready pod -l app=chartmuseum
+      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig -n giantswarm port-forward service/chartmuseum-chartmuseum 8080:8080 &
       KUBECTL_PID=$!
       sleep 5
 
       curl --data-binary "@${PACKAGE_PATH}" http://localhost:8080/api/charts
 
       kill $KUBECTL_PID
+
+  - name: install-app
+    image: quay.io/giantswarm/kubectl:1.19.2
+    script: |
+      #!/bin/sh
+
+      CHART_DIR=$(find $(resources.inputs.app-repository.path)/helm -maxdepth 1 -type d -name "*-app")
+      CHART_NAME=${CHART_DIR##*/}
+
+      PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
+      CHART_VERSION="${PACKAGE_PATH##*/$CHART_NAME-}"
+      CHART_VERSION="${CHART_VERSION%.tgz}"
+
+      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig -n giantswarm create -f - << EOF
+      apiVersion: application.giantswarm.io/v1alpha1
+      kind: App
+      metadata:
+        name: "${CHART_NAME}"
+        namespace: giantswarm
+        labels:
+          app: "${CHART_NAME}"
+          app-operator.giantswarm.io/version: "0.0.0"
+      spec:
+        catalog: chartmuseum
+        version: "${CHART_VERSION}"
+        kubeConfig:
+          inCluster: true
+        name: "${CHART_NAME}"
+        namespace: app-test-ns
+      EOF

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -51,7 +51,7 @@ spec:
       KUBECTL_PID=$!
       sleep 5
 
-      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
+      curl --data-binary "@${PACKAGE_PATH}" http://localhost:8080/api/charts
 
       kill $KUBECTL_PID
 #

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -11,10 +11,10 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  - name: tenant-kubeconfig
   steps:
   - name: app-build-suite
-    image: quay.io/geraldpape/abs # TODO use official image
-    imagePullPolicy: Always
+    image: quay.io/giantswarm/app-build-suite:0.0.0-bda3e22540a607e47e479210fdaec75ba7c1af91
     script: |
       #!/bin/sh
 

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -35,7 +35,7 @@ spec:
       echo "${PACKAGE_PATH}"
 
   - name: upload-chart
-    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
+    image: quay.io/giantswarm/kubectl:1.19.2
     script: |
       #!/bin/sh
 

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -54,22 +54,3 @@ spec:
       curl --data-binary "@${PACKAGE_PATH}" http://localhost:8080/api/charts
 
       kill $KUBECTL_PID
-#
-#
-#  - name: pytest
-#    image: python:3.7-slim
-#    script: |
-#      #!/bin/sh
-#
-#      pip install pipenv
-#
-#      cd /workspace/app-repository/test/kat
-#      pipenv sync
-#      pipenv run pytest --log-cli-level info --full-trace --verbosity=8 . \
-#      --cluster-type existing \
-#      --kube-config /kube.config \
-#      --values-file ../../${config_file} \
-#      --chart-path \"helm/${chart_name}\" \
-#      --chart-version ${CHART_VERSION} \
-#      --log-cli-level info \
-#      --junitxml=../../${test_res_file}"

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -11,9 +11,6 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
-  # TODO remove this once standup is used for cluster creation
-  - name: tenant-kubeconfig
-    description: Holds kubeconfig of the tenant cluster
   steps:
   - name: app-build-suite
     image: quay.io/geraldpape/abs # TODO use official image
@@ -37,18 +34,26 @@ spec:
       PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
       echo "${PACKAGE_PATH}"
 
-#  - name: upload-chart
-#    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
-#    script: |
-#      #!/bin/sh
-#
-#      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chart-museum 8080:8080 &
-#      KUBECTL_PID=$!
-#      sleep 5
-#
-#      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
-#
-#      kill $KUBECTL_PID
+  - name: upload-chart
+    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
+    script: |
+      #!/bin/sh
+
+      CHART_DIR=$(find $(resources.inputs.app-repository.path)/helm -maxdepth 1 -type d -name "*-app")
+      CHART_NAME=${CHART_DIR##*/}
+      PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
+
+      echo "${CHART_DIR}"
+      echo "${CHART_NAME}"
+      echo "${PACKAGE_PATH}"
+
+      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chartmuseum-chartmuseum 8080:8080 &
+      KUBECTL_PID=$!
+      sleep 5
+
+      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
+
+      kill $KUBECTL_PID
 #
 #
 #  - name: pytest


### PR DESCRIPTION
This PR adds:

- A prow config setting up presubmit configuration for giantswarm/giantswarm-todo-app (I already added the webhook to giantswarm/giantswarm-todo-app)
- Tekton tasks for bootstrapping clusters with `apptestctl`, validating and packaging apps with `app-build-suite` (Needs official container image), uploading the app to a remote chartmuseum
- A Tekton pipeline stringing together cluster creation, bootstrapping, app validation stuff
- Small docs improvement

TODO:

- Actual App testing
- Maybe more documentation
- ?
