### PR TITLE
Use releases repo to create cluster

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -41,13 +41,6 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-      # TODO remove this once standup is used for cluster creation
-      - name: tenant-kubeconfig
-        secret:
-          secretName: tenant-kubeconfig
-          items:
-          - key: kubeconfig
-            path: kubeconfig
     trigger: "/test this"
     rerun_command: "/test this"
   giantswarm/releases:

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -29,6 +29,9 @@ presubmits:
       - name: app-repository
         resourceRef:
           name: PROW_IMPLICIT_GIT_REF
+      - name: releases
+        resourceRef:
+          name: releases-master
       workspaces:
       - name: cluster
         volumeClaimTemplate:

--- a/tekton/pipelines/kustomization.yaml
+++ b/tekton/pipelines/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - aws.yaml
 - cis.yaml
 - cncf.yaml
+- pipelineresources.yaml
 - test-app.yaml

--- a/tekton/pipelines/pipelineresources.yaml
+++ b/tekton/pipelines/pipelineresources.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineResource
+metadata:
+  name: releases-master
+  namespace: test-workloads
+spec:
+  type: git
+  params:
+    - name: url
+      value: https://github.com/giantswarm/releases.git
+    - name: revision
+      value: master

--- a/tekton/pipelines/pipelineresources.yaml
+++ b/tekton/pipelines/pipelineresources.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
   name: releases-master

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -7,21 +7,27 @@ spec:
   resources:
   - name: app-repository
     type: git
-  # TODO: add releases repository resource once standup is used for cluster creation
+  - name: releases
+    type: git
   workspaces:
   - name: cluster
   - name: tenant-kubeconfig # TODO remove this once standup is used for cluster creation
   tasks:
-  #- name: create-cluster
-  #  taskRef:
-  #    name: create-cluster
-  #  workspaces:
-  #  - name: cluster
-  #    workspace: cluster
-  #  resources:
-  #    inputs:
-  #    - name: releases
-  #      resource: releases
+  - name: create-cluster
+    taskRef:
+      name: create-cluster
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    params:
+    - name: create-extra-args
+      value:
+        - "--provider aws"
+        - "--release v12.3.0"
+    resources:
+      inputs:
+      - name: releases
+        resource: releases
 
   - name: wait-for-ready
     # runAfter: [create-cluster]

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -11,7 +11,6 @@ spec:
     type: git
   workspaces:
   - name: cluster
-  - name: tenant-kubeconfig # TODO remove this once standup is used for cluster creation
   tasks:
   - name: create-cluster
     taskRef:
@@ -30,7 +29,7 @@ spec:
         resource: releases
 
   - name: wait-for-ready
-    # runAfter: [create-cluster]
+    runAfter: [create-cluster]
     timeout: 1h0m0s
     taskRef:
       name: wait-for-ready

--- a/tekton/pipelines/test-app.yaml
+++ b/tekton/pipelines/test-app.yaml
@@ -35,7 +35,7 @@ spec:
       name: wait-for-ready
     workspaces:
     - name: cluster
-      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
+      workspace: cluster
 
   - name: prepare-cluster
     runAfter: [wait-for-ready]
@@ -43,7 +43,7 @@ spec:
       name: app-test-preparation
     workspaces:
     - name: cluster
-      workspace: tenant-kubeconfig # TODO use cluster workspace for using kubeconfig from standup
+      workspace: cluster
 
   - name: test-app
     runAfter: [prepare-cluster]
@@ -56,14 +56,11 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
-    # TODO remove this once standup is used for cluster creation
-    - name: tenant-kubeconfig
-      workspace: tenant-kubeconfig
 
-  #finally:
-  #- name: cleanup
-  #  taskRef:
-  #    name: cleanup
-  #  workspaces:
-  #  - name: cluster
-  #    workspace: cluster
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+    - name: cluster
+      workspace: cluster

--- a/tekton/tasks/app-test-preparation.yaml
+++ b/tekton/tasks/app-test-preparation.yaml
@@ -10,6 +10,7 @@ spec:
   steps:
   - name: prepare-cluster
     image: quay.io/geraldpape/atc # TODO use official image
+    imagePullPolicy: Always
     script: |
       #!/bin/sh
       apptestctl bootstrap --kubeconfig "$(cat $(workspaces.cluster.path)/kubeconfig)"

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -40,11 +40,11 @@ spec:
         mountPath: /etc/endpoints-config
       - name: kubeconfig
         mountPath: /etc/kubeconfig
-    script: |
-      #! /bin/sh
-      standup create \
-      --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig/kubeconfig \
-      --releases /workspace/releases \
-      --output $(workspaces.cluster.path) \
-      $(params.create-extra-args[*])
+    args: [
+      "create",
+      "--config", "/etc/endpoints-config/config",
+      "--kubeconfig", "/etc/kubeconfig/kubeconfig",
+      "--releases", "/workspace/releases",
+      "--output", "$(workspaces.cluster.path)",
+      "$(params.create-extra-args[*])"
+    ]

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -4,6 +4,10 @@ metadata:
   name: create-cluster
   namespace: test-workloads
 spec:
+  params:
+  - name: create-extra-args
+    type: array
+    description: Extra args to pass to the create command
   resources:
     inputs:
     - name: releases
@@ -42,4 +46,5 @@ spec:
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig/kubeconfig \
       --releases /workspace/releases \
-      --output $(workspaces.cluster.path)
+      --output $(workspaces.cluster.path) \
+      $(params.create-extra-args[*])

--- a/tekton/tasks/test-app.yaml
+++ b/tekton/tasks/test-app.yaml
@@ -11,9 +11,6 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
-  # TODO remove this once standup is used for cluster creation
-  - name: tenant-kubeconfig
-    description: Holds kubeconfig of the tenant cluster
   steps:
   - name: app-build-suite
     image: quay.io/geraldpape/abs # TODO use official image
@@ -37,18 +34,26 @@ spec:
       PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
       echo "${PACKAGE_PATH}"
 
-#  - name: upload-chart
-#    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
-#    script: |
-#      #!/bin/sh
-#
-#      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chart-museum 8080:8080 &
-#      KUBECTL_PID=$!
-#      sleep 5
-#
-#      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
-#
-#      kill $KUBECTL_PID
+  - name: upload-chart
+    image: bitnami/kubectl:1.19.2 # use quay.io/giantswarm/kubectl:1.19.2
+    script: |
+      #!/bin/sh
+
+      CHART_DIR=$(find $(resources.inputs.app-repository.path)/helm -maxdepth 1 -type d -name "*-app")
+      CHART_NAME=${CHART_DIR##*/}
+      PACKAGE_PATH=$(find $(workspaces.cluster.path) -maxdepth 1 -type f -name "${CHART_NAME}-0.0.0-*.tgz")
+
+      echo "${CHART_DIR}"
+      echo "${CHART_NAME}"
+      echo "${PACKAGE_PATH}"
+
+      kubectl --kubeconfig $(workspaces.cluster.path)/kubeconfig port-forward -n giantswarm service/chartmuseum-chartmuseum 8080:8080 &
+      KUBECTL_PID=$!
+      sleep 5
+
+      curl --data-binary "@${CHART_FILE_NAME}" http://localhost:8080/api/charts
+
+      kill $KUBECTL_PID
 #
 #
 #  - name: pytest


### PR DESCRIPTION
Haven't tested this but it's just an idea of what you might do if the releases repo is the only issue for using the create task. 
Not perfect as you have to pass the provider and release version. You can have have different triggers (/test aws/kvm/azure) for different providers and make the pipeline take it as a param so you don't duplicate it, but I'm not sure how you can work around the release part.