### PR TITLE
Split release creation into own task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install kustomize
           command: |
-            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_linux_amd64.tar.gz
+            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.4/kustomize_v3.8.4_linux_amd64.tar.gz
             tar xzf ./kustomize_v*_*_amd64.tar.gz
             ./kustomize version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install kustomize
           command: |
-            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz
+            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.4/kustomize_v3.8.4_linux_amd64.tar.gz
             tar xzf ./kustomize_v*_*_amd64.tar.gz
             ./kustomize version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install kustomize
           command: |
-            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.4/kustomize_v3.8.4_linux_amd64.tar.gz
+            curl -s -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.5/kustomize_v3.5.5_linux_amd64.tar.gz
             tar xzf ./kustomize_v*_*_amd64.tar.gz
             ./kustomize version
       - run:

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -9,6 +9,9 @@ spec:
     type: git
   workspaces:
   - name: cluster
+  params:
+  - name: PROW_JOB_ID
+    type: string
   tasks:
   - name: create-release
     taskRef:

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -23,15 +23,11 @@ spec:
       inputs:
       - name: releases
         resource: releases
-  - name: upload-to-s3-bucket
+
+  - name: test-aws
     runAfter: [create-release]
     taskRef:
-      name: upload-to-s3-bucket
-    params:
-    - name: prow-job-id
-      value: "$(params.PROW_JOB_ID)"
-    - name: file-to-upload
-      value: $(workspaces.cluster.path)/release-id
+      name: aws
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -10,7 +10,7 @@ spec:
   workspaces:
   - name: cluster
   tasks:
-  - name: run-tests
+  - name: create-release
     taskRef:
       name: aws
     workspaces:

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -12,7 +12,23 @@ spec:
   tasks:
   - name: create-release
     taskRef:
-      name: aws
+      name: create-release
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    resources:
+      inputs:
+      - name: releases
+        resource: releases
+  - name: upload-to-s3-bucket
+    runAfter: [create-release]
+    taskRef:
+      name: upload-to-s3-bucket
+    params:
+    - name: prow-job-id
+      value: "$(params.PROW_JOB_ID)"
+    - name: file-to-upload
+      value: $(workspaces.cluster.path)/release-id
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -13,9 +13,9 @@ spec:
   - name: PROW_JOB_ID
     type: string
   tasks:
-  - name: create-cluster
+  - name: create-release
     taskRef:
-      name: create-cluster
+      name: create-release
     workspaces:
     - name: cluster
       workspace: cluster
@@ -23,6 +23,14 @@ spec:
       inputs:
       - name: releases
         resource: releases
+
+  - name: create-cluster
+    runAfter: [create-release]
+    taskRef:
+      name: create-cluster
+    workspaces:
+    - name: cluster
+      workspace: cluster
 
   - name: wait-for-ready
     runAfter: [create-cluster]

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -25,6 +25,7 @@ spec:
         resource: releases
 
   - name: create-cluster
+    runAfter: [create-release]
     taskRef:
       name: create-cluster
     workspaces:

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -13,9 +13,9 @@ spec:
   - name: PROW_JOB_ID
     type: string
   tasks:
-  - name: create-cluster
+  - name: create-release
     taskRef:
-      name: create-cluster
+      name: create-release
     workspaces:
     - name: cluster
       workspace: cluster
@@ -23,6 +23,13 @@ spec:
       inputs:
       - name: releases
         resource: releases
+
+  - name: create-cluster
+    taskRef:
+      name: create-cluster
+    workspaces:
+    - name: cluster
+      workspace: cluster
 
   - name: wait-for-ready
     runAfter: [create-cluster]

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -3,6 +3,8 @@ kind: Task
 metadata:
   name: cleanup
   namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
 spec:
   volumes:
     - name: endpoints-config
@@ -16,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
+    image: replaced/by/kustomize
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: replaced/by/kustomize
+    image: quay.io/giantswarm/standup:1.1.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -16,7 +16,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:1.0.0
+    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -3,6 +3,8 @@ kind: Task
 metadata:
   name: create-cluster
   namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
 spec:
   volumes:
   - name: endpoints-config
@@ -16,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
+    image: replaced/by/kustomize
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: replaced/by/kustomize
+    image: quay.io/giantswarm/standup:1.1.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -4,10 +4,6 @@ metadata:
   name: create-cluster
   namespace: test-workloads
 spec:
-  resources:
-    inputs:
-    - name: releases
-      type: git
   volumes:
   - name: endpoints-config
     secret:

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -16,7 +16,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:1.0.0-c6235d830b1a6f7b7540d9d60d0d1fe666b40709
+    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      standup create cluster\
+      standup create cluster \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig/kubeconfig \
       --release $(cat $(workspaces.cluster.path)/release-id) \

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -28,4 +28,5 @@ spec:
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig/kubeconfig \
       --release $(cat $(workspaces.cluster.path)/release-id) \
+      --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -27,12 +27,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: replaced/by/kustomize
+    image: quay.io/giantswarm/standup:1.1.0
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: replaced/by/kustomize
+    image: quay.io/giantswarm/standup:1.1.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: create-cluster
+  name: create-release
   namespace: test-workloads
 spec:
   resources:
@@ -19,7 +19,17 @@ spec:
   - name: cluster
     description: Cluster information is stored here.
   steps:
-  - name: create-cluster
+  - name: chown-releases
+    command:
+    - chown
+    - -R
+    - 1000:1000
+    - /workspace
+    image: quay.io/giantswarm/standup:1.0.0
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  - name: create-release
     image: quay.io/giantswarm/standup:1.0.0-c6235d830b1a6f7b7540d9d60d0d1fe666b40709
     volumeMounts:
       - name: endpoints-config
@@ -28,8 +38,8 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      standup create cluster\
+      standup create release \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig/kubeconfig \
-      --release $(cat $(workspaces.cluster.path)/release-id) \
+      --releases /workspace/releases \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -25,12 +25,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:1.0.0
+    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:1.0.0-c6235d830b1a6f7b7540d9d60d0d1fe666b40709
+    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -3,6 +3,8 @@ kind: Task
 metadata:
   name: create-release
   namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
 spec:
   resources:
     inputs:
@@ -25,12 +27,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
+    image: replaced/by/kustomize
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:1.0.0-913610f30f1396113c92d0da0a1f4891d8b3202b
+    image: replaced/by/kustomize
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -1,11 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-patches:
-- path: standup-image-patch.yaml
-  target:
-    labelSelector: app.kubernetes.io/name=standup
-
 resources:
 - aws.yaml
 - cis.yaml

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -1,5 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+patches:
+- path: standup-image-patch.yaml
+  target:
+    labelSelector: app.kubernetes.io/name=standup
+
 resources:
 - aws.yaml
 - cis.yaml

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 - cleanup.yaml
 - cncf.yaml
 - create-cluster.yaml
+- create-release.yaml
 - upload-to-s3-bucket.yaml
 - wait-for-ready.yaml

--- a/tekton/tasks/standup-image-patch.yaml
+++ b/tekton/tasks/standup-image-patch.yaml
@@ -4,4 +4,4 @@ metadata:
   name: unused
 spec:
   steps:
-    image: quay.io/giantswarm/standup:1.1.0
+  - image: quay.io/giantswarm/standup:1.1.0

--- a/tekton/tasks/standup-image-patch.yaml
+++ b/tekton/tasks/standup-image-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: unused
-spec:
-  steps:
-  - image: quay.io/giantswarm/standup:1.1.0

--- a/tekton/tasks/standup-image-patch.yaml
+++ b/tekton/tasks/standup-image-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: unused
+spec:
+  steps:
+    image: quay.io/giantswarm/standup:1.1.0

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: replaced/by/kustomize
+    image: quay.io/giantswarm/standup:1.1.0
     script: |
       #! /bin/sh
       standup wait \

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -3,13 +3,15 @@ kind: Task
 metadata:
   name: wait-for-ready
   namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
 spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:1.0.0
+    image: replaced/by/kustomize
     script: |
       #! /bin/sh
       standup wait \


### PR DESCRIPTION
This splits release creation into its own task and makes it composable. Tested with cncf / aws tests and works fine.