### PR TITLE
Update cluster-role.yaml

### DIFF
--- a/control-plane/cluster-role.yaml
+++ b/control-plane/cluster-role.yaml
@@ -4,7 +4,15 @@ metadata:
   name: release-manager
 rules:
   - apiGroups:
+      - cluster.x-k8s.io
+      - infrastructure.giantswarm.io
       - release.giantswarm.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
     resources:
       - "*"
     verbs:


### PR DESCRIPTION
We need to extend the RBAC rules in order to run the jobs for `awscnfm` on the control planes. I am not sure how open we want to be with that. I can see that the test infra just needs access to everything. 

```
[test-aws : run-tests] panic: {"kind":"unknown","annotation":"clusters.cluster.x-k8s.io is forbidden: User \"system:serviceaccount:giantswarm:test-infra\" cannot create resource \"clusters\" in API group \"cluster.x-k8s.io\" in the namespace \"default\"","stack":[{"file":"/root/project/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":79},{"file":"/root/project/cmd/action/create/cluster/defaultcontrolplane/runner.go","line":32},{"file":"/root/project/pkg/plan/executor.go","line":84},{"file":"/go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go","line":13},{"file":"/root/project/pkg/plan/executor.go","line":92},{"file":"/root/project/cmd/plan/pl001/runner.go","line":63},{"file":"/root/project/cmd/plan/pl001/runner.go","line":31},{"file":"/root/project/main.go","line":78}]}
```