### PR TITLE
Split provider kubeconfigs into separate files

### DIFF
--- a/secrets/generate-standup-kubeconfig-secret.sh
+++ b/secrets/generate-standup-kubeconfig-secret.sh
@@ -40,11 +40,10 @@ for provider in aws azure kvm; do
     # Read service account cert from the secret
     KUBECONFIG=$installation_kubeconfig kubectl -n giantswarm get secret/"$secret_name" -o jsonpath='{.data.ca\.crt}'  | base64 --decode > "$tmp_dir/ca_cert"
 
-    result_kubeconfig="$tmp_dir/result_kubeconfig"
     # Add service account data to the kubeconfig
     (
-    touch "$result_kubeconfig"
-    export KUBECONFIG="$result_kubeconfig"
+    export KUBECONFIG="$tmp_dir/$provider-kubeconfig"
+    touch $KUBECONFIG
 
     # Add data from the service account to the result kubeconfig
     kubectl config set-cluster "giantswarm-cluster-$installation" \
@@ -65,6 +64,8 @@ done
 
 kubectl create secret generic standup-kubeconfig \
     -n test-workloads \
-    --from-file=kubeconfig="$result_kubeconfig" \
+    --from-file=aws="$tmp_dir/aws-kubeconfig" \
+    --from-file=azure="$tmp_dir/azure-kubeconfig" \
+    --from-file=kvm="$tmp_dir/kvm-kubeconfig" \
     --dry-run=client -o yaml \
     > "$script_dir/standup-kubeconfig-secret.yaml"

--- a/secrets/standup-endpoints-config-secret.yaml
+++ b/secrets/standup-endpoints-config-secret.yaml
@@ -1,10 +1,8 @@
 # Format of <CONFIG> is:
 # aws:
-#   context: giantswarm-<CP-name>
 #   endpoint: <API endpoint URL with protocol prefix>
 #   token: <API token (uuid)>
 # other-provider:
-#   context: giantswarm-<CP-name>
 #   endpoint: <API endpoint URL with protocol prefix>
 #   token: <API token (uuid)>
 apiVersion: v1

--- a/tekton/tasks/aws.yaml
+++ b/tekton/tasks/aws.yaml
@@ -20,7 +20,7 @@ spec:
       script: |
         #! /bin/sh
         
-        export AWSCNFM_CONTROLPLANE_KUBECONFIG=/etc/controlplane/kubeconfig
+        export AWSCNFM_CONTROLPLANE_KUBECONFIG=/etc/controlplane/aws
         export AWSCNFM_RELEASEVERSION=$(cat $(workspaces.cluster.path)/release-id)
         
         awscnfm plan pl001

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
+    image: quay.io/giantswarm/standup:2.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:1.1.1-3aed822d39bcde35f1d92df99962ac5bdc7b9ebc
+    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:1.1.1
+    image: quay.io/giantswarm/standup:1.1.1-3aed822d39bcde35f1d92df99962ac5bdc7b9ebc
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -28,7 +28,7 @@ spec:
       #! /bin/sh
       standup cleanup \
       --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig/kubeconfig \
+      --kubeconfig /etc/kubeconfig \
       --cluster $(cat $(workspaces.cluster.path)/cluster-id) \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --release $(cat $(workspaces.cluster.path)/release-id)

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -28,7 +28,7 @@ spec:
       #! /bin/sh
       standup create cluster \
       --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig/kubeconfig \
+      --kubeconfig /etc/kubeconfig \
       --release $(cat $(workspaces.cluster.path)/release-id) \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
+    image: quay.io/giantswarm/standup:2.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:1.1.1
+    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -28,7 +28,6 @@ spec:
       #! /bin/sh
       standup create cluster \
       --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig \
       --release $(cat $(workspaces.cluster.path)/release-id) \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -27,12 +27,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:1.1.1
+    image: quay.io/giantswarm/standup:2.0.0
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
+    image: quay.io/giantswarm/standup:2.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -42,6 +42,6 @@ spec:
       #! /bin/sh
       standup create release \
       --config /etc/endpoints-config/config \
-      --kubeconfig /etc/kubeconfig/kubeconfig \
+      --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -32,7 +32,7 @@ spec:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:1.1.1
+    image: quay.io/giantswarm/standup:1.1.1-3aed822d39bcde35f1d92df99962ac5bdc7b9ebc
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -32,7 +32,7 @@ spec:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:1.1.1-3aed822d39bcde35f1d92df99962ac5bdc7b9ebc
+    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:1.1.1
+    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
     script: |
       #! /bin/sh
       standup wait \

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:1.1.1-63036dfea4a1a63f34c3fc3a663256e849842859
+    image: quay.io/giantswarm/standup:2.0.0
     script: |
       #! /bin/sh
       standup wait \


### PR DESCRIPTION
`standup-kubeconfig` secret now contains 3 files: aws, azure and kvm, each containing the kubeconfig for the corresponding installation