### PR TITLE
Add skaffolding for Azure e2e tests

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -91,3 +91,27 @@ presubmits:
                   storage: 10Mi
     trigger: "/test aws"
     rerun_command: "/test aws"
+  - name: azure
+    agent: tekton-pipeline
+    max_concurrency: 5
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: azure
+      serviceAccountName: test-runs
+      resources:
+        - name: releases
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test azure"
+    rerun_command: "/test azure"

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -24,10 +24,35 @@ spec:
       - name: releases
         resource: releases
 
-  - name: test-azure
+  - name: create-cluster
     runAfter: [create-release]
+    taskRef:
+      name: create-cluster
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: wait-for-ready
+    runAfter: [create-cluster]
+    timeout: 1h0m0s
+    taskRef:
+      name: wait-for-ready
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: test-azure
+    runAfter: [wait-for-ready]
     taskRef:
       name: azure
     workspaces:
     - name: cluster
       workspace: cluster
+
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+      - name: cluster
+        workspace: cluster

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: azure
+  namespace: test-workloads
+spec:
+  resources:
+  - name: releases
+    type: git
+  workspaces:
+  - name: cluster
+  params:
+  - name: PROW_JOB_ID
+    type: string
+  tasks:
+  - name: create-release
+    taskRef:
+      name: create-release
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    resources:
+      inputs:
+      - name: releases
+        resource: releases
+
+  - name: test-azure
+    runAfter: [create-release]
+    taskRef:
+      name: azure
+    workspaces:
+    - name: cluster
+      workspace: cluster

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: azure
+  namespace: test-workloads
+spec:
+  workspaces:
+    - name: cluster
+      description: Cluster information is stored here.
+  steps:
+    - name: run-tests
+      image: quay.io/giantswarm/alpine:3.12.0
+      script: |
+        #! /bin/sh
+        
+        echo "hello"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14530

This adds a new `prow` command `/test azure` that runs the `azure` pipeline which currently only executes a dummy task that prints `hello`.

The plan is to have this working before start creating real tests.