### PR TITLE
Use non existing namespace for giantswarm sonobuoy plugin

### DIFF
--- a/images/conformance-tests/run-sonobuoy-tests
+++ b/images/conformance-tests/run-sonobuoy-tests
@@ -27,7 +27,7 @@ run_giantswarm() {
   log "Running giantswarm"
   sonobuoy run \
     --kubeconfig "$kubeconfig_path" \
-    --namespace "$(cat "${CLUSTER_ID_PATH}")" \
+    --namespace "$(cat "${CLUSTER_ID_PATH}")-sonobuoy" \
     --plugin https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml \
     --plugin-env giantswarm.TC_KUBECONFIG="$(cat "${TC_KUBECONFIG_PATH}")" \
     --plugin-env giantswarm.CP_KUBECONFIG="$(cat "${KUBECONFIG_PATH}")" \

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -29,6 +29,3 @@ spec:
     - name: kubeconfig
       secret:
         secretName: sonobuoy-kubeconfig
-  workspaces:
-    - description: Cluster information is stored here.
-      name: cluster


### PR DESCRIPTION
The block in the `Task` is duplicated, so I'm removing it.

Sonobuoy will fail if using an existing namespace, so we need to pass a non existing one.