### PR TITLE
Pipeline that creates cluster using latest stable release and then upgrades it

### DIFF
--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -57,6 +57,19 @@ spec:
     - name: cluster
       workspace: cluster
 
+  - name: upload-to-s3-bucket
+    runAfter: [test-azure]
+    taskRef:
+      name: upload-to-s3-bucket
+    params:
+      - name: prow-job-id
+        value: "$(params.PROW_JOB_ID)"
+      - name: file-to-upload
+        value: $(workspaces.cluster.path)/sonobuoy-results.tar
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
   finally:
   - name: cleanup
     taskRef:

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -13,24 +13,24 @@ spec:
   - name: PROW_JOB_ID
     type: string
   tasks:
+  - name: create-release
+    taskRef:
+      name: create-release
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    resources:
+      inputs:
+        - name: releases
+          resource: releases
+
   - name: create-cluster-stable
+    runAfter: [create-release]
     taskRef:
       name: create-cluster-stable
     workspaces:
       - name: cluster
         workspace: cluster
-
-  - name: create-release
-    runAfter: [create-cluster-stable]
-    taskRef:
-      name: create-release
-    workspaces:
-      - name: cluster
-        workspace: cluster
-    resources:
-      inputs:
-        - name: releases
-          resource: releases
 
   - name: wait-for-ready
     runAfter: [create-cluster-stable]

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -50,7 +50,7 @@ spec:
       workspace: cluster
 
   - name: test-azure
-    runAfter: [wait-for-ready]
+    runAfter: [upgrade-cluster]
     taskRef:
       name: azure
     workspaces:

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: azure-upgrade
+  namespace: test-workloads
+spec:
+  resources:
+  - name: releases
+    type: git
+  workspaces:
+  - name: cluster
+  params:
+  - name: PROW_JOB_ID
+    type: string
+  tasks:
+  - name: create-cluster-latest
+    taskRef:
+      name: create-cluster-latest
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: create-release
+    runAfter: [create-cluster-latest]
+    taskRef:
+      name: create-release
+    workspaces:
+      - name: cluster
+        workspace: cluster
+    resources:
+      inputs:
+        - name: releases
+          resource: releases
+
+  - name: wait-for-ready
+    runAfter: [create-cluster-latest]
+    timeout: 1h0m0s
+    taskRef:
+      name: wait-for-ready
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: upgrade-cluster
+    runAfter: [wait-for-ready]
+    taskRef:
+      name: upgrade-cluster
+    workspaces:
+    - name: cluster
+      workspace: cluster
+
+  - name: test-azure
+    runAfter: [wait-for-ready]
+    taskRef:
+      name: azure
+    workspaces:
+    - name: cluster
+      workspace: cluster
+
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+      - name: cluster
+        workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -13,15 +13,15 @@ spec:
   - name: PROW_JOB_ID
     type: string
   tasks:
-  - name: create-cluster-latest
+  - name: create-cluster-stable
     taskRef:
-      name: create-cluster-latest
+      name: create-cluster-stable
     workspaces:
       - name: cluster
         workspace: cluster
 
   - name: create-release
-    runAfter: [create-cluster-latest]
+    runAfter: [create-cluster-stable]
     taskRef:
       name: create-release
     workspaces:
@@ -33,7 +33,7 @@ spec:
           resource: releases
 
   - name: wait-for-ready
-    runAfter: [create-cluster-latest]
+    runAfter: [create-cluster-stable]
     timeout: 1h0m0s
     taskRef:
       name: wait-for-ready

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster-latest.yaml
+++ b/tekton/tasks/create-cluster-latest.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: create-cluster-latest
+  namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
+spec:
+  volumes:
+  - name: endpoints-config
+    secret:
+      secretName: standup-endpoints-config
+  - name: kubeconfig
+    secret:
+      secretName: standup-kubeconfig
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  params:
+  - name: release-id
+    description: The release version to use when creating the cluster.
+    default: s3-bucket-credentials-secret
+  steps:
+  - name: create-cluster-latest
+    image: quay.io/giantswarm/standup:2.1.0
+    volumeMounts:
+      - name: endpoints-config
+        mountPath: /etc/endpoints-config
+      - name: kubeconfig
+        mountPath: /etc/kubeconfig
+    script: |
+      #! /bin/sh
+      LATEST_RELEASE=`find /workspace/releases/azure -regex 'azure/v[0-9]*\.[0-9]*\.[0-9]*' | sort | tail -n1`
+      standup create cluster \
+      --config /etc/endpoints-config/config \
+      --release ${LATEST_RELEASE#"azure/"} \
+      --provider $(cat $(workspaces.cluster.path)/provider) \
+      --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: create-cluster-latest
+  name: create-cluster-stable
   namespace: test-workloads
   labels:
     app.kubernetes.io/name: "standup"
@@ -21,7 +21,7 @@ spec:
     description: The release version to use when creating the cluster.
     default: s3-bucket-credentials-secret
   steps:
-  - name: create-cluster-latest
+  - name: create-cluster-stable
     image: quay.io/giantswarm/standup:2.1.0
     volumeMounts:
       - name: endpoints-config
@@ -30,9 +30,9 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      LATEST_RELEASE=`find /workspace/releases/azure -regex 'azure/v[0-9]*\.[0-9]*\.[0-9]*' | sort | tail -n1`
+      LATEST_STABLE_RELEASE=`find /workspace/releases/azure -regex 'azure/v[0-9]*\.[0-9]*\.[0-9]*' | sort | tail -n1`
       standup create cluster \
       --config /etc/endpoints-config/config \
-      --release ${LATEST_RELEASE#"azure/"} \
+      --release ${LATEST_STABLE_RELEASE#"azure/"} \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -16,13 +16,9 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
-  params:
-  - name: release-id
-    description: The release version to use when creating the cluster.
-    default: s3-bucket-credentials-secret
   steps:
   - name: create-cluster-stable
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -30,9 +26,10 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      LATEST_STABLE_RELEASE=`find /workspace/releases/azure -regex 'azure/v[0-9]*\.[0-9]*\.[0-9]*' | sort | tail -n1`
+      LATEST_STABLE_RELEASE=$(kubectl --kubeconfig /etc/kubeconfig/azure get releases -o json | jq -r '[.items | sort_by(.metadata.name) | reverse[] | select(.metadata.name | test("v[0-9]*\\.[0-9]*\\.[0-9]*$")) ][].metadata.name' | head -n1)
+      echo "Creating cluster using release ${LATEST_STABLE_RELEASE}"
       standup create cluster \
       --config /etc/endpoints-config/config \
-      --release ${LATEST_STABLE_RELEASE#"azure/"} \
+      --release ${LATEST_STABLE_RELEASE} \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -27,12 +27,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upgrade-cluster
+  namespace: test-workloads
+spec:
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  steps:
+  - name: upgrade-cluster
+    image: quay.io/giantswarm/standup:2.1.0
+    script: |
+      #! /bin/sh
+      echo "This will upgrade the cluster to $(cat $(workspaces.cluster.path)/release-id)"

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -9,7 +9,8 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: upgrade-cluster
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     script: |
       #! /bin/sh
-      echo "This will upgrade the cluster to $(cat $(workspaces.cluster.path)/release-id)"
+      echo "Upgrading cluster $(cat $(workspaces.cluster.path)/cluster-id) to $(cat $(workspaces.cluster.path)/release-id)"
+      kubectl --kubeconfig /etc/kubeconfig/azure -n$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}') patch cluster/$(cat $(workspaces.cluster.path)/cluster-id) -p '{"metadata":{"labels":{"release.giantswarm.io/version": "$(cat $(workspaces.cluster.path)/release-id)"}}}' --type=merge

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -10,6 +10,9 @@ spec:
   steps:
   - name: upgrade-cluster
     image: quay.io/giantswarm/standup:2.3.0
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
       echo "Upgrading cluster $(cat $(workspaces.cluster.path)/cluster-id) to $(cat $(workspaces.cluster.path)/release-id)"

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -4,6 +4,10 @@ metadata:
   name: upgrade-cluster
   namespace: test-workloads
 spec:
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: standup-kubeconfig
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
@@ -15,18 +19,29 @@ spec:
       mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
+
+      set -eo pipefail
+
       CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
       CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
+      RELEASE_ID=$(cat $(workspaces.cluster.path)/release-id)
 
-      echo "Upgrading cluster ${CLUSTER_ID} to $(cat $(workspaces.cluster.path)/release-id)"
+      # Wait for the operator to be ready
+      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null
+      do
+        echo "Cluster '${CLUSTER_ID}' is not Ready yet"
+        sleep 10
+      done
+
+      echo "Upgrading cluster ${CLUSTER_ID} to ${RELEASE_ID}"
 
       # Update cluster label to trigger upgrade
-      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/${CLUSTER_ID} -p '{"metadata":{"labels":{"release.giantswarm.io/version": "$(cat $(workspaces.cluster.path)/release-id)"}}}' --type=merge
+      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/${CLUSTER_ID} -p "{\"metadata\":{\"labels\":{\"release.giantswarm.io/version\": \"${RELEASE_ID}\"}}}" --type=merge
 
       # Wait for the operator to pick up the change and start upgrading
       while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
       do
-        echo "Cluster '${CLUSTER_ID}' is not upgrading yet"
+        echo "Cluster '${CLUSTER_ID}' is not Upgrading yet"
         sleep 10
       done
 

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -15,5 +15,25 @@ spec:
       mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      echo "Upgrading cluster $(cat $(workspaces.cluster.path)/cluster-id) to $(cat $(workspaces.cluster.path)/release-id)"
-      kubectl --kubeconfig /etc/kubeconfig/azure -n$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}') patch cluster/$(cat $(workspaces.cluster.path)/cluster-id) -p '{"metadata":{"labels":{"release.giantswarm.io/version": "$(cat $(workspaces.cluster.path)/release-id)"}}}' --type=merge
+      CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
+      CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
+
+      echo "Upgrading cluster ${CLUSTER_ID} to $(cat $(workspaces.cluster.path)/release-id)"
+
+      # Update cluster label to trigger upgrade
+      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/${CLUSTER_ID} -p '{"metadata":{"labels":{"release.giantswarm.io/version": "$(cat $(workspaces.cluster.path)/release-id)"}}}' --type=merge
+
+      # Wait for the operator to pick up the change and start upgrading
+      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
+      do
+        echo "Cluster '${CLUSTER_ID}' is not upgrading yet"
+        sleep 10
+      done
+
+      # Wait for the upgrade to finish
+      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="False")'>/dev/null
+      do
+        echo "Cluster ${CLUSTER_ID} is still upgrading"
+        sleep 10
+      done
+

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:2.1.0
+    image: quay.io/giantswarm/standup:2.3.0
     script: |
       #! /bin/sh
       standup wait \


### PR DESCRIPTION
I still need to test it, but what do you folks think about this approach?

It uses two pipelines
- one that creates cluster using the release that's being tested
- another one that creates cluster using latest stable release, then upgrades to release being tested


The azure-upgrade pipeline would look like

```
Create Cluster using Stable ---|---> Wait cluster ready ---|--> Upgrade cluster ---> Run tests ---> clean up
                               |                           |
                               |---> Create release -------|
                               
```

while regular pipeline

```
Create release ---> Create Cluster ---> Wait cluster ready ---> Run tests ---> clean up
```