### PR TITLE
Upload giantswarm sonobuoy plugin results to S3

### DIFF
--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -49,6 +49,19 @@ spec:
     - name: cluster
       workspace: cluster
 
+  - name: upload-to-s3-bucket
+    runAfter: [test-azure]
+    taskRef:
+      name: upload-to-s3-bucket
+    params:
+      - name: prow-job-id
+        value: "$(params.PROW_JOB_ID)"
+      - name: file-to-upload
+        value: $(workspaces.cluster.path)/sonobuoy-results.tar
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
   finally:
   - name: cleanup
     taskRef:


### PR DESCRIPTION
Let's upload to S3 the sonobuoy results for the giantswarm plugin as well.