### PR TITLE
Add Organization resource for the management cluster

### DIFF
--- a/control-plane/organization.yaml
+++ b/control-plane/organization.yaml
@@ -1,0 +1,7 @@
+apiVersion: security.giantswarm.io/v1alpha1
+kind: Organization
+metadata:
+  name: conformance-testing
+  labels:
+    giantswarm.io/conformance-testing: "true"
+spec: { }

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -30,6 +30,7 @@ spec:
       echo "Creating cluster using release ${LATEST_STABLE_RELEASE}"
       standup create cluster \
       --config /etc/endpoints-config/config \
+      --kubeconfig /etc/kubeconfig \
       --release ${LATEST_STABLE_RELEASE} \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -28,6 +28,7 @@ spec:
       #! /bin/sh
       standup create cluster \
       --config /etc/endpoints-config/config \
+      --kubeconfig /etc/kubeconfig \
       --release $(cat $(workspaces.cluster.path)/release-id) \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)


### PR DESCRIPTION
[These changes](https://github.com/giantswarm/standup/pull/86) to `standup` make the `kubeconfig` parameter required when creating a cluster.

In this PR I also added the `Organization` CR that was used when creating a cluster. I labeled in such a way that it will be picked up by `standup`.