### PR TITLE
Extract waiting for condition to its own task

### DIFF
--- a/tekton/pipelines/azure-operator.yaml
+++ b/tekton/pipelines/azure-operator.yaml
@@ -36,11 +36,11 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: wait-for-ready
+  - name: wait-for-condition-ready
     runAfter: [create-cluster]
     timeout: 1h0m0s
     taskRef:
-      name: wait-for-ready
+      name: wait-for-condition-ready
     workspaces:
       - name: cluster
         workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -32,11 +32,11 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: wait-for-ready
+  - name: wait-for-condition-ready
     runAfter: [create-cluster-stable]
     timeout: 1h0m0s
     taskRef:
-      name: wait-for-ready
+      name: wait-for-condition-ready
     workspaces:
       - name: cluster
         workspace: cluster

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -32,11 +32,11 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: wait-for-ready
+  - name: wait-for-condition-ready
     runAfter: [create-cluster]
     timeout: 1h0m0s
     taskRef:
-      name: wait-for-ready
+      name: wait-for-condition-ready
     workspaces:
       - name: cluster
         workspace: cluster

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster-stable
-    image: quay.io/giantswarm/standup:2.3.0
+    image: quay.io/giantswarm/standup:2.5.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:2.3.0
+    image: quay.io/giantswarm/standup:2.5.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -13,7 +13,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: upgrade-cluster
-    image: quay.io/giantswarm/standup:2.3.0
+    image: quay.io/giantswarm/standup:2.5.0
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig
@@ -25,24 +25,6 @@ spec:
       CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
       CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
       RELEASE_ID=$(cat $(workspaces.cluster.path)/release-id)
-
-      # Wait for the cluster to be ready
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null
-      do
-        echo "$(date): Cluster '${CLUSTER_ID}' is not Ready yet"
-        sleep 10
-      done
-
-      echo "$(date): Cluster ${CLUSTER_ID} is Ready"
-
-      # Wait for the cluster to be completely created
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Creating" and .status=="False")'>/dev/null
-      do
-        echo "$(date): Cluster '${CLUSTER_ID}' is still creating"
-        sleep 10
-      done
-
-      echo "$(date): Cluster ${CLUSTER_ID} has finished creating"
 
       echo "$(date): Upgrading cluster ${CLUSTER_ID} to ${RELEASE_ID}"
 

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: wait-for-condition-ready
+  namespace: test-workloads
+spec:
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: standup-kubeconfig
+  workspaces:
+    - name: cluster
+      description: Cluster information is stored here.
+  steps:
+    - name: wait-for-condition-ready
+      image: quay.io/giantswarm/standup:2.5.0
+      volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+      script: |
+        #! /bin/sh
+
+        set -eo pipefail
+
+        CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
+        CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
+        RELEASE_ID=$(cat $(workspaces.cluster.path)/release-id)
+
+        # Wait for the cluster to be ready
+        while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null
+        do
+          echo "$(date): Cluster '${CLUSTER_ID}' is not Ready yet"
+          sleep 10
+        done
+
+        echo "$(date): Cluster ${CLUSTER_ID} is Ready"
+
+        # Wait for the cluster to be completely created
+        while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Creating" and .status=="False")'>/dev/null
+        do
+          echo "$(date): Cluster '${CLUSTER_ID}' is still creating"
+          sleep 10
+        done
+
+        echo "$(date): Cluster ${CLUSTER_ID} has finished creating"


### PR DESCRIPTION
I extracted the logic to know if the `Cluster` is created and ready to its own `Task`, and I replaced the `standup wait` `Task` with this new mechanism.

I also updated `standup` version here and there.