### PR TITLE
Add pipeline to debug azure tests, and task to gen kubeconfig

### DIFF
--- a/tekton/pipelines/debug-azure.yaml
+++ b/tekton/pipelines/debug-azure.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: debug-azure
+  namespace: test-workloads
+spec:
+  resources:
+  - name: releases
+    type: git
+  workspaces:
+  - name: cluster
+  params:
+  - name: PROW_JOB_ID
+    type: string
+  - name: CLUSTER_ID
+    type: string
+  tasks:
+  - name: generate-workload-cluster-kubeconfig
+    taskRef:
+      name: generate-workload-cluster-kubeconfig
+    params:
+    - name: cluster-id
+      value: "$(params.CLUSTER_ID)"
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: wait-for-condition-ready
+    runAfter: [generate-workload-cluster-kubeconfig]
+    timeout: 1h0m0s
+    taskRef:
+      name: wait-for-condition-ready
+    workspaces:
+    - name: cluster
+      workspace: cluster
+
+  - name: test-azure
+    runAfter: [wait-for-condition-ready]
+    taskRef:
+      name: azure
+    workspaces:
+    - name: cluster
+      workspace: cluster

--- a/tekton/pipelines/debug-azure.yaml
+++ b/tekton/pipelines/debug-azure.yaml
@@ -38,6 +38,9 @@ spec:
     runAfter: [wait-for-condition-ready]
     taskRef:
       name: azure
+    params:
+    - name: test-deletion
+      value: "0"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -7,6 +7,10 @@ spec:
   workspaces:
     - name: cluster
       description: Cluster information is stored here.
+  params:
+  - name: test-deletion
+    description: Whether or not test deletion of clusters.
+    default: "1"
   steps:
     - name: run-tests
       image: quay.io/giantswarm/run-sonobuoy-tests
@@ -21,6 +25,8 @@ spec:
           value: $(workspaces.cluster.path)/sonobuoy-results.tar
         - name: PROVIDER
           value: azure
+        - name: TEST_DELETION
+          value: $(params.test-deletion)
       script: |
         #! /bin/sh
         run-sonobuoy-tests giantswarm

--- a/tekton/tasks/generate-workload-cluster-kubeconfig.yaml
+++ b/tekton/tasks/generate-workload-cluster-kubeconfig.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: generate-workload-cluster-kubeconfig
+  namespace: test-workloads
+  labels:
+    app.kubernetes.io/name: "standup"
+spec:
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  params:
+  - name: cluster-id
+    description: ID of the workload cluster to use
+  volumes:
+  - name: kubeconfig
+    secret:
+      secretName: standup-kubeconfig
+  steps:
+  - name: generate-workload-cluster-kubeconfig
+    image: quay.io/giantswarm/devctl:4.1.0
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: /etc/kubeconfig
+    script: |
+      #! /bin/sh
+      set -e
+
+      echo -n "$(params.cluster-id)" > $(workspaces.cluster.path)/cluster-id
+      devctl gen kubeconfig --clusterID $(params.cluster-id) --kubeconfig /etc/kubeconfig/azure --output $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -24,7 +24,6 @@ spec:
 
         CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
         CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
-        RELEASE_ID=$(cat $(workspaces.cluster.path)/release-id)
 
         # Wait for the cluster to be ready
         while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null


### PR DESCRIPTION
I've been using this pipeline to debug tests. Instead of waiting for a new cluster to be created as part of the pipeline, this _debug_ pipeline receives a cluster ID as parameter. That way I create the cluster once, and then I can iterate without having to wait for cluster creation.