### PR TITLE
Communicate between Tasks using explicit params and results

### DIFF
--- a/tekton/pipelines/azure-operator.yaml
+++ b/tekton/pipelines/azure-operator.yaml
@@ -41,6 +41,11 @@ spec:
     timeout: 1h0m0s
     taskRef:
       name: wait-for-condition-ready
+    params:
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
+      - name: cluster-id
+        value: "$(tasks.create-cluster.results.cluster-id)"
     workspaces:
       - name: cluster
         workspace: cluster

--- a/tekton/pipelines/azure-operator.yaml
+++ b/tekton/pipelines/azure-operator.yaml
@@ -42,10 +42,10 @@ spec:
     taskRef:
       name: wait-for-condition-ready
     params:
-      - name: kubeconfig-path
-        value: "/etc/kubeconfig/azure"
       - name: cluster-id
         value: "$(tasks.create-cluster.results.cluster-id)"
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
     workspaces:
       - name: cluster
         workspace: cluster
@@ -54,6 +54,9 @@ spec:
     runAfter: [wait-for-condition-ready]
     taskRef:
       name: azure
+    params:
+    - name: kubeconfig-path
+      value: "/etc/kubeconfig/azure"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -38,10 +38,10 @@ spec:
     taskRef:
       name: wait-for-condition-ready
     params:
-      - name: kubeconfig-path
-        value: "/etc/kubeconfig/azure"
       - name: cluster-id
         value: "$(tasks.create-cluster-stable.results.cluster-id)"
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
     workspaces:
       - name: cluster
         workspace: cluster
@@ -53,6 +53,8 @@ spec:
     params:
       - name: cluster-id
         value: "$(tasks.create-cluster-stable.results.cluster-id)"
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
       - name: release-id
         value: "$(tasks.create-release.results.release-id)"
     workspaces:
@@ -63,6 +65,9 @@ spec:
     runAfter: [upgrade-cluster]
     taskRef:
       name: azure
+    params:
+    - name: kubeconfig-path
+      value: "/etc/kubeconfig/azure"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -37,6 +37,11 @@ spec:
     timeout: 1h0m0s
     taskRef:
       name: wait-for-condition-ready
+    params:
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
+      - name: cluster-id
+        value: "$(tasks.create-cluster-stable.results.cluster-id)"
     workspaces:
       - name: cluster
         workspace: cluster
@@ -45,6 +50,11 @@ spec:
     runAfter: [wait-for-condition-ready]
     taskRef:
       name: upgrade-cluster
+    params:
+      - name: cluster-id
+        value: "$(tasks.create-cluster-stable.results.cluster-id)"
+      - name: release-id
+        value: "$(tasks.create-release.results.release-id)"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -38,10 +38,10 @@ spec:
     taskRef:
       name: wait-for-condition-ready
     params:
-      - name: kubeconfig-path
-        value: "/etc/kubeconfig/azure"
       - name: cluster-id
         value: "$(tasks.create-cluster.results.cluster-id)"
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
     workspaces:
       - name: cluster
         workspace: cluster
@@ -50,6 +50,9 @@ spec:
     runAfter: [wait-for-condition-ready]
     taskRef:
       name: azure
+    params:
+    - name: kubeconfig-path
+      value: "/etc/kubeconfig/azure"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -37,6 +37,11 @@ spec:
     timeout: 1h0m0s
     taskRef:
       name: wait-for-condition-ready
+    params:
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
+      - name: cluster-id
+        value: "$(tasks.create-cluster.results.cluster-id)"
     workspaces:
       - name: cluster
         workspace: cluster

--- a/tekton/pipelines/debug-azure.yaml
+++ b/tekton/pipelines/debug-azure.yaml
@@ -21,6 +21,8 @@ spec:
     params:
     - name: cluster-id
       value: "$(params.CLUSTER_ID)"
+    - name: kubeconfig-path
+      value: "/etc/kubeconfig/azure"
     workspaces:
       - name: cluster
         workspace: cluster
@@ -31,10 +33,10 @@ spec:
     taskRef:
       name: wait-for-condition-ready
     params:
-      - name: kubeconfig-path
-        value: "/etc/kubeconfig/azure"
       - name: cluster-id
         value: "$(params.CLUSTER_ID)"
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
     workspaces:
     - name: cluster
       workspace: cluster
@@ -44,6 +46,8 @@ spec:
     taskRef:
       name: azure
     params:
+    - name: kubeconfig-path
+      value: "/etc/kubeconfig/azure"
     - name: test-deletion
       value: "0"
     workspaces:

--- a/tekton/pipelines/debug-azure.yaml
+++ b/tekton/pipelines/debug-azure.yaml
@@ -30,6 +30,11 @@ spec:
     timeout: 1h0m0s
     taskRef:
       name: wait-for-condition-ready
+    params:
+      - name: kubeconfig-path
+        value: "/etc/kubeconfig/azure"
+      - name: cluster-id
+        value: "$(params.CLUSTER_ID)"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -8,7 +8,11 @@ spec:
     - name: cluster
       description: Cluster information is stored here.
   params:
+  - name: kubeconfig-path
+    type: string
+    description: Management Cluster kubeconfig path.
   - name: test-deletion
+    type: string
     description: Whether or not test deletion of clusters.
     default: "1"
   steps:
@@ -18,7 +22,7 @@ spec:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig
         - name: KUBECONFIG_PATH
-          value: /etc/kubeconfig/azure
+          value: $(params.kubeconfig-path)
         - name: CLUSTER_ID_PATH
           value: $(workspaces.cluster.path)/cluster-id
         - name: RESULTS_PATH

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -34,3 +34,5 @@ spec:
       --release ${LATEST_STABLE_RELEASE} \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)
+
+      cat $(workspaces.cluster.path)/cluster-id > $(results.cluster-id.path)

--- a/tekton/tasks/create-cluster-stable.yaml
+++ b/tekton/tasks/create-cluster-stable.yaml
@@ -16,6 +16,9 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  results:
+  - name: cluster-id
+    description: The ID of the created cluster.
   steps:
   - name: create-cluster-stable
     image: quay.io/giantswarm/standup:2.5.0

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -16,6 +16,13 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  params:
+  - name: release-id
+    type: string
+    description: Release ID to use when creating the cluster.
+  results:
+  - name: cluster-id
+    description: The ID of the created cluster.
   steps:
   - name: create-cluster
     image: quay.io/giantswarm/standup:2.5.0
@@ -29,6 +36,8 @@ spec:
       standup create cluster \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
-      --release $(cat $(workspaces.cluster.path)/release-id) \
+      --release $(params.release-id) \
       --provider $(cat $(workspaces.cluster.path)/provider) \
       --output $(workspaces.cluster.path)
+
+      cat $(workspaces.cluster.path)/cluster-id > $(results.cluster-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -20,6 +20,9 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  results:
+  - name: release-id
+    description: The ID of the created release.
   steps:
   - name: chown-releases
     command:
@@ -45,3 +48,5 @@ spec:
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path)
+
+      cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -22,6 +22,9 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  results:
+  - name: release-id
+    description: The ID of the created release.
   steps:
   - name: chown-releases
     command:
@@ -49,3 +52,5 @@ spec:
       --releases-path /workspace/releases \
       --output $(workspaces.cluster.path) \
       --provider azure
+
+      cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/generate-workload-cluster-kubeconfig.yaml
+++ b/tekton/tasks/generate-workload-cluster-kubeconfig.yaml
@@ -12,6 +12,8 @@ spec:
   params:
   - name: cluster-id
     description: ID of the workload cluster to use
+  - name: kubeconfig-path
+    description: Kubeconfig path for the Management Cluster managing the Workload Cluster.
   volumes:
   - name: kubeconfig
     secret:
@@ -27,4 +29,4 @@ spec:
       set -e
 
       echo -n "$(params.cluster-id)" > $(workspaces.cluster.path)/cluster-id
-      devctl gen kubeconfig --clusterID $(params.cluster-id) --kubeconfig /etc/kubeconfig/azure --output $(workspaces.cluster.path)/kubeconfig
+      devctl gen kubeconfig --clusterID $(params.cluster-id) --kubeconfig $(params.kubeconfig-path) --output $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -15,6 +15,9 @@ spec:
   - name: cluster-id
     type: string
     description: Cluster ID for the cluster that will be upgraded.
+  - name: kubeconfig-path
+    type: string
+    description: Kubeconfig path for the cluster where sonobuoy will run.
   - name: release-id
     type: string
     description: Release ID that the cluster will be upgraded to.
@@ -29,7 +32,7 @@ spec:
 
       set -eo pipefail
 
-      CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(params.cluster-id) | awk '{print $1}')
+      CLUSTER_NAMESPACE=$(kubectl --kubeconfig $(params.kubeconfig-path) get clusters -A | grep $(params.cluster-id) | awk '{print $1}')
 
       echo "$(date): Upgrading cluster $(params.cluster-id) to $(params.release-id)"
 
@@ -37,17 +40,17 @@ spec:
       release="$(echo "${RELEASE_ID#"v"}")"
 
       # Update cluster label to trigger upgrade
-      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/$(params.cluster-id) -p "{\"metadata\":{\"labels\":{\"release.giantswarm.io/version\": \"${release}\"}}}" --type=merge
+      kubectl --kubeconfig $(params.kubeconfig-path) -n${CLUSTER_NAMESPACE} patch cluster/$(params.cluster-id) -p "{\"metadata\":{\"labels\":{\"release.giantswarm.io/version\": \"${release}\"}}}" --type=merge
 
       # Wait for the operator to pick up the change and start upgrading
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
+      while ! kubectl --kubeconfig $(params.kubeconfig-path) get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
       do
         echo "$(date): Cluster '$(params.cluster-id)' is not Upgrading yet"
         sleep 10
       done
 
       # Wait for the upgrade to finish
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="False")'>/dev/null
+      while ! kubectl --kubeconfig $(params.kubeconfig-path) get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="False")'>/dev/null
       do
         echo "$(date): Cluster $(params.cluster-id) is still upgrading"
         sleep 10

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -11,6 +11,13 @@ spec:
   workspaces:
   - name: cluster
     description: Cluster information is stored here.
+  params:
+  - name: cluster-id
+    type: string
+    description: Cluster ID for the cluster that will be upgraded.
+  - name: release-id
+    type: string
+    description: Release ID that the cluster will be upgraded to.
   steps:
   - name: upgrade-cluster
     image: quay.io/giantswarm/standup:2.5.0
@@ -22,29 +29,27 @@ spec:
 
       set -eo pipefail
 
-      CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
-      CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
-      RELEASE_ID=$(cat $(workspaces.cluster.path)/release-id)
+      CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(params.cluster-id) | awk '{print $1}')
 
-      echo "$(date): Upgrading cluster ${CLUSTER_ID} to ${RELEASE_ID}"
+      echo "$(date): Upgrading cluster $(params.cluster-id) to $(params.release-id)"
 
       # Remove initial "v" from RELEASE_ID
       release="$(echo "${RELEASE_ID#"v"}")"
 
       # Update cluster label to trigger upgrade
-      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/${CLUSTER_ID} -p "{\"metadata\":{\"labels\":{\"release.giantswarm.io/version\": \"${release}\"}}}" --type=merge
+      kubectl --kubeconfig /etc/kubeconfig/azure -n${CLUSTER_NAMESPACE} patch cluster/$(params.cluster-id) -p "{\"metadata\":{\"labels\":{\"release.giantswarm.io/version\": \"${release}\"}}}" --type=merge
 
       # Wait for the operator to pick up the change and start upgrading
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
+      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="True")'>/dev/null
       do
-        echo "$(date): Cluster '${CLUSTER_ID}' is not Upgrading yet"
+        echo "$(date): Cluster '$(params.cluster-id)' is not Upgrading yet"
         sleep 10
       done
 
       # Wait for the upgrade to finish
-      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="False")'>/dev/null
+      while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Upgrading" and .status=="False")'>/dev/null
       do
-        echo "$(date): Cluster ${CLUSTER_ID} is still upgrading"
+        echo "$(date): Cluster $(params.cluster-id) is still upgrading"
         sleep 10
       done
 

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -12,12 +12,12 @@ spec:
     - name: cluster
       description: Cluster information is stored here.
   params:
-  - name: kubeconfig-path
-    type: string
-    description: Kubeconfig path for the cluster where sonobuoy will run.
   - name: cluster-id
     type: string
     description: Cluster ID for the cluster that we want to wait for.
+  - name: kubeconfig-path
+    type: string
+    description: Kubeconfig path for the cluster where sonobuoy will run.
   steps:
     - name: wait-for-condition-ready
       image: quay.io/giantswarm/standup:2.5.0

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -11,6 +11,13 @@ spec:
   workspaces:
     - name: cluster
       description: Cluster information is stored here.
+  params:
+  - name: kubeconfig-path
+    type: string
+    description: Kubeconfig path for the cluster where sonobuoy will run.
+  - name: cluster-id
+    type: string
+    description: Cluster ID for the cluster that we want to wait for.
   steps:
     - name: wait-for-condition-ready
       image: quay.io/giantswarm/standup:2.5.0
@@ -22,23 +29,22 @@ spec:
 
         set -eo pipefail
 
-        CLUSTER_NAMESPACE=$(kubectl --kubeconfig /etc/kubeconfig/azure get clusters -A | grep $(cat $(workspaces.cluster.path)/cluster-id) | awk '{print $1}')
-        CLUSTER_ID=$(cat $(workspaces.cluster.path)/cluster-id)
+        CLUSTER_NAMESPACE=$(kubectl --kubeconfig $(params.kubeconfig-path) get clusters -A | grep $(params.cluster-id) | awk '{print $1}')
 
         # Wait for the cluster to be ready
-        while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null
+        while ! kubectl --kubeconfig $(params.kubeconfig-path) get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Ready" and .status=="True")'>/dev/null
         do
-          echo "$(date): Cluster '${CLUSTER_ID}' is not Ready yet"
+          echo "$(date): Cluster '$(params.cluster-id)' is not Ready yet"
           sleep 10
         done
 
-        echo "$(date): Cluster ${CLUSTER_ID} is Ready"
+        echo "$(date): Cluster $(params.cluster-id) is Ready"
 
         # Wait for the cluster to be completely created
-        while ! kubectl --kubeconfig /etc/kubeconfig/azure get clusters -n${CLUSTER_NAMESPACE} ${CLUSTER_ID} -o json | jq -e '.status.conditions[] | select(.type=="Creating" and .status=="False")'>/dev/null
+        while ! kubectl --kubeconfig $(params.kubeconfig-path) get clusters -n${CLUSTER_NAMESPACE} $(params.cluster-id) -o json | jq -e '.status.conditions[] | select(.type=="Creating" and .status=="False")'>/dev/null
         do
-          echo "$(date): Cluster '${CLUSTER_ID}' is still creating"
+          echo "$(date): Cluster '$(params.cluster-id)' is still creating"
           sleep 10
         done
 
-        echo "$(date): Cluster ${CLUSTER_ID} has finished creating"
+        echo "$(date): Cluster $(params.cluster-id) has finished creating"


### PR DESCRIPTION
We share data between `Tasks` creating files in the file system. That's the preferred mechanism in Tekton, but sometimes these values are hard to discover and you need to know where to find them. Tekton offers a way to explicitly declare these values: results.

With these changes `Tasks` that generate a value that will be consumed by other `Tasks` explicitly declare a `result`. That way, the value for that `result` can be consumed later. This automatically creates a dependency between the tasks, and Tekton will make sure one gets executed before the other.

WDYT?