### PR TITLE
Add release-id param to cis and cncf pipelines

### DIFF
--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -30,7 +30,7 @@ spec:
       name: create-cluster
     params:
     - name: release-id
-      value: "$(tasks.get-latest-release.results.release-id)"
+      value: "$(tasks.create-release.results.release-id)"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -28,6 +28,9 @@ spec:
     runAfter: [create-release]
     taskRef:
       name: create-cluster
+    params:
+    - name: release-id
+      value: "$(tasks.get-latest-release.results.release-id)"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -30,7 +30,7 @@ spec:
       name: create-cluster
     params:
     - name: release-id
-      value: "$(tasks.get-latest-release.results.release-id)"
+      value: "$(tasks.create-release.results.release-id)"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -28,6 +28,9 @@ spec:
     runAfter: [create-release]
     taskRef:
       name: create-cluster
+    params:
+    - name: release-id
+      value: "$(tasks.get-latest-release.results.release-id)"
     workspaces:
     - name: cluster
       workspace: cluster


### PR DESCRIPTION
It seems that https://github.com/giantswarm/test-infra/pull/93 had some unintended side-effects and no one has tried running these pipelines since. I tested this manually by editing the cncf pipeline on rfjh2 and it seems to have worked: https://tekton.giantswarm.io/#/namespaces/test-workloads/pipelineruns/8dd3f73d-7567-11eb-a5cb-4a4e6774c371?pipelineTask=create-cluster