### PR TITLE
Only upload results to S3 when tests fail

### DIFF
--- a/tekton/pipelines/azure-operator.yaml
+++ b/tekton/pipelines/azure-operator.yaml
@@ -77,20 +77,23 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: upload-to-s3-bucket
-    runAfter: [manage-sonobuoy-results]
+  finally:
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+    - input: $(tasks.manage-sonobuoy-results.status)
+      operator: in
+      values: ["Failed"]
     taskRef:
       name: upload-to-s3-bucket
     params:
-      - name: prow-job-id
-        value: "$(params.PROW_JOB_ID)"
-      - name: file-to-upload
-        value: $(workspaces.cluster.path)/sonobuoy-results.tar
+    - name: prow-job-id
+      value: "$(params.PROW_JOB_ID)"
+    - name: file-to-upload
+      value: $(workspaces.cluster.path)/sonobuoy-results.tar
     workspaces:
       - name: cluster
         workspace: cluster
 
-  finally:
   - name: cleanup
     taskRef:
       name: cleanup

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -99,8 +99,12 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: upload-to-s3-bucket
-    runAfter: [manage-sonobuoy-results]
+  finally:
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+      - input: $(tasks.manage-sonobuoy-results.status)
+        operator: in
+        values: ["Failed"]
     taskRef:
       name: upload-to-s3-bucket
     params:
@@ -112,7 +116,6 @@ spec:
       - name: cluster
         workspace: cluster
 
-  finally:
   - name: cleanup
     taskRef:
       name: cleanup

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -73,8 +73,12 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: upload-to-s3-bucket
-    runAfter: [manage-sonobuoy-results]
+  finally:
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+      - input: $(tasks.manage-sonobuoy-results.status)
+        operator: in
+        values: ["Failed"]
     taskRef:
       name: upload-to-s3-bucket
     params:
@@ -86,7 +90,6 @@ spec:
       - name: cluster
         workspace: cluster
 
-  finally:
   - name: cleanup
     taskRef:
       name: cleanup

--- a/tekton/pipelines/upgrade-to-this-azure-operator.yaml
+++ b/tekton/pipelines/upgrade-to-this-azure-operator.yaml
@@ -103,8 +103,12 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: upload-to-s3-bucket
-    runAfter: [manage-sonobuoy-results]
+  finally:
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+      - input: $(tasks.manage-sonobuoy-results.status)
+        operator: in
+        values: ["Failed"]
     taskRef:
       name: upload-to-s3-bucket
     params:
@@ -116,7 +120,6 @@ spec:
       - name: cluster
         workspace: cluster
 
-  finally:
   - name: cleanup
     taskRef:
       name: cleanup


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15856

These changes make the pipeline to *only* upload the test logs to S3 when tests fail. Before this, logs wouldn't be uploaded when tests fail.