### PR TITLE
Pathtype leads to a 404

### DIFF
--- a/tekton/dashboard/tekton-ingresses.yaml
+++ b/tekton/dashboard/tekton-ingresses.yaml
@@ -22,7 +22,6 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Exact
             backend:
               service:
                 name: tekton-dashboard
@@ -32,7 +31,6 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Exact
             backend:
               service:
                 name: tekton-dashboard


### PR DESCRIPTION
When not removing pathType in ingress spec users faces a 404 because of missing JS files.

example log:
```
46.114.35.111 - - [10/Mar/2021:10:12:19 +0000] "GET /runtime.ddc93156ff2baf76849f.js HTTP/2.0" 404 548 "https://tekton.giantswarm.io/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.192 Safari/537.36" 38 0.000 [upstream-default-backend] [] 127.0.0.1:8181 548 0.000 404 cf0818b3467210bbd06d56cd1fbd21a4
```