### PR TITLE
Fix apps test

### DIFF
--- a/control-plane/cluster-role.yaml
+++ b/control-plane/cluster-role.yaml
@@ -6,6 +6,7 @@ rules:
   - apiGroups:
       - cluster.x-k8s.io
       - infrastructure.giantswarm.io
+      - provider.giantswarm.io
       - release.giantswarm.io
       - security.giantswarm.io
     resources:

--- a/tekton/pipelines/apps.yaml
+++ b/tekton/pipelines/apps.yaml
@@ -59,6 +59,8 @@ spec:
       params:
         - name: kubeconfig-path
           value: $(workspaces.cluster.path)/kubeconfig
+        - name: sonobuoy-namespace
+          value: "$(tasks.create-cluster.results.cluster-id)-sonobuoy"
       workspaces:
         - name: cluster
           workspace: cluster

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -7,10 +7,6 @@ spec:
   workspaces:
     - name: cluster
       description: Cluster information is stored here.
-  params:
-    - name: kubeconfig-path
-      type: string
-      description: Management Cluster kubeconfig path.
   steps:
     - name: download-sonobuoy-plugin
       image: busybox
@@ -20,9 +16,9 @@ spec:
     - name: run-tests
       image: sonobuoy/sonobuoy:v0.20.0
       env:
-        - name: KUBECONFIG_PATH
-          value: $(params.kubeconfig-path)
-        - name: CLUSTER_ID_PATH
+        - name: "KUBECONFIG_PATH"
+          value: $(workspaces.cluster.path)/kubeconfig
+        - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id
       script: |
         #! /bin/sh


### PR DESCRIPTION
Tekton has failed to run the `apps` task.
```
invalid input params for task apps: missing values for these params which have no default values: [kubeconfig-path]
```

https://tekton.giantswarm.io/#/namespaces/test-workloads/pipelineruns/339ae76e-a121-11eb-b460-0ada3b9a0011?pipelineTask=create-release&step=chown-releases


And sonobuoy test as well. 
```
time="2021-04-19T16:17:25Z" level=error msg="error attempting to run sonobuoy: failed to get namespace sonobuoy: namespaces \"sonobuoy\" not found"

```