### PR TITLE
Upload sonobuoy's test result to s3 from cis, apps test

### DIFF
--- a/tekton/pipelines/apps.yaml
+++ b/tekton/pipelines/apps.yaml
@@ -58,7 +58,7 @@ spec:
         name: manage-sonobuoy-results
       params:
         - name: kubeconfig-path
-          value: $(workspaces.cluster.path)/kubeconfig
+          value: "/etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider)"
         - name: sonobuoy-namespace
           value: "$(tasks.create-cluster.results.cluster-id)-sonobuoy"
       workspaces:

--- a/tekton/pipelines/apps.yaml
+++ b/tekton/pipelines/apps.yaml
@@ -65,23 +65,26 @@ spec:
         - name: cluster
           workspace: cluster
 
-    - name: upload-to-s3-bucket
-      runAfter: [manage-sonobuoy-results]
-      taskRef:
-        name: upload-to-s3-bucket
-      params:
-        - name: prow-job-id
-          value: "$(params.PROW_JOB_ID)"
-        - name: file-to-upload
-          value: $(workspaces.cluster.path)/sonobuoy-results.tar
-      workspaces:
-        - name: cluster
-          workspace: cluster
-
   finally:
-    - name: cleanup
-      taskRef:
-        name: cleanup
-      workspaces:
-        - name: cluster
-          workspace: cluster
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+      - input: $(tasks.manage-sonobuoy-results.status)
+        operator: in
+        values: ["Failed"]
+    taskRef:
+      name: upload-to-s3-bucket
+    params:
+      - name: prow-job-id
+        value: "$(params.PROW_JOB_ID)"
+      - name: file-to-upload
+        value: $(workspaces.cluster.path)/sonobuoy-results.tar
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+      - name: cluster
+        workspace: cluster

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -63,20 +63,23 @@ spec:
       - name: cluster
         workspace: cluster
 
-  - name: upload-to-s3-bucket
-    runAfter: [manage-sonobuoy-results]
+  finally:
+  - name: upload-to-s3-bucket # executed only when tests fail
+    when:
+      - input: $(tasks.manage-sonobuoy-results.status)
+        operator: in
+        values: ["Failed"]
     taskRef:
       name: upload-to-s3-bucket
     params:
-    - name: prow-job-id
-      value: "$(params.PROW_JOB_ID)"
-    - name: file-to-upload
-      value: $(workspaces.cluster.path)/sonobuoy-results.tar
+      - name: prow-job-id
+        value: "$(params.PROW_JOB_ID)"
+      - name: file-to-upload
+        value: $(workspaces.cluster.path)/sonobuoy-results.tar
     workspaces:
-    - name: cluster
-      workspace: cluster
+      - name: cluster
+        workspace: cluster
 
-  finally:
   - name: cleanup
     taskRef:
       name: cleanup

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -16,14 +16,12 @@ spec:
     - name: run-tests
       image: sonobuoy/sonobuoy:v0.20.0
       env:
-        - name: "KUBECONFIG_PATH"
-          value: $(workspaces.cluster.path)/kubeconfig
         - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id
       script: |
         #! /bin/sh
         /sonobuoy run \
-            --kubeconfig "${KUBECONFIG_PATH}" \
+            --kubeconfig "/etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider)" \
             --namespace "$(cat "${CLUSTER_ID_PATH}")-sonobuoy" \
             --plugin $(workspaces.cluster.path)/giantswarm-plugin.yaml \
             --plugin-env giantswarm.CP_KUBECONFIG="$(cat /etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider))" \

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -26,7 +26,7 @@ spec:
             --kubeconfig "${KUBECONFIG_PATH}" \
             --namespace "$(cat "${CLUSTER_ID_PATH}")-sonobuoy" \
             --plugin $(workspaces.cluster.path)/giantswarm-plugin.yaml \
-            --plugin-env giantswarm.CP_KUBECONFIG="$(cat /etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider)) \
+            --plugin-env giantswarm.CP_KUBECONFIG="$(cat /etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider))" \
             --plugin-env giantswarm.CLUSTER_ID="$(cat "${CLUSTER_ID_PATH}")" \
             --plugin-env giantswarm.E2E_FOCUS="App" \
             --mode=quick \

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -26,7 +26,7 @@ spec:
             --kubeconfig "${KUBECONFIG_PATH}" \
             --namespace "$(cat "${CLUSTER_ID_PATH}")-sonobuoy" \
             --plugin $(workspaces.cluster.path)/giantswarm-plugin.yaml \
-            --plugin-env giantswarm.CP_KUBECONFIG="$(cat "${KUBECONFIG_PATH}")" \
+            --plugin-env giantswarm.CP_KUBECONFIG="$(cat /etc/kubeconfig/$(cat $(workspaces.cluster.path)/provider)) \
             --plugin-env giantswarm.CLUSTER_ID="$(cat "${CLUSTER_ID_PATH}")" \
             --plugin-env giantswarm.E2E_FOCUS="App" \
             --mode=quick \

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -15,7 +15,6 @@ spec:
     type: string
     description: Whether or not test deletion of clusters.
     default: "1"
-    type: string
   steps:
     - name: download-sonobuoy-plugin
       image: busybox

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -39,10 +39,6 @@ spec:
         /sonobuoy results "$outfile"
         /sonobuoy results "$outfile" --mode detailed
         mv "$outfile" "$(params.results-path)"
-
-        if /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" | grep failed >/dev/null; then
-          exit 1
-        fi
       volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -39,6 +39,10 @@ spec:
         /sonobuoy results "$outfile"
         /sonobuoy results "$outfile" --mode detailed
         mv "$outfile" "$(params.results-path)"
+
+        if /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" | grep failed >/dev/null; then
+          exit 1
+        fi
       volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig


### PR DESCRIPTION
From `/apps test` I found out tekton haven't managed to upload sonobuoy result into AWS S3 if it received failures from sonobuoy test. 
![image](https://user-images.githubusercontent.com/2532687/115429010-4586dd00-a203-11eb-9dfe-6f29601992a8.png)

