### PR TITLE
increase the timeout for running awscnfm

### DIFF
--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -26,6 +26,7 @@ spec:
 
   - name: test-aws
     runAfter: [create-release]
+    timeout: 1h30m0s
     taskRef:
       name: aws
     workspaces:


### PR DESCRIPTION
Currently the timeout hit us when running awscnfm, I'd like to increase it a bit. Usually we need to wait a bit longer until everything has been deleted.