### PR TITLE
Change prow timeout from default

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -101,6 +101,7 @@ presubmits:
       pipelineRef:
         name: aws
       serviceAccountName: test-runs
+      timeout: 5h0m0s
       resources:
         - name: releases
           resourceRef:


### PR DESCRIPTION
Prow has a default timeout of 1 hour. We can set something really high here as we do proper timeouts in tekton.

We really need to get rid of this prow setup to simplify it and handle it all through tekton :(