### PR TITLE
Support AWS China conformance testing on `giraffe`

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -124,7 +124,7 @@ presubmits:
     skip_report: false
     pipeline_run_spec:
       pipelineRef:
-        name: aws_china
+        name: aws-china
       serviceAccountName: test-runs
       timeout: 5h0m0s
       resources:

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -117,6 +117,31 @@ presubmits:
                   storage: 10Mi
     trigger: "/test aws"
     rerun_command: "/test aws"
+  - name: aws-china
+    agent: tekton-pipeline
+    max_concurrency: 3
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: aws_china
+      serviceAccountName: test-runs
+      timeout: 5h0m0s
+      resources:
+        - name: releases
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test aws-china"
+    rerun_command: "/test aws-china"
   - name: azure
     agent: tekton-pipeline
     max_concurrency: 5

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -92,31 +92,6 @@ presubmits:
                 storage: 10Mi
     trigger: "/test cncf"
     rerun_command: "/test cncf"
-  - name: aws
-    agent: tekton-pipeline
-    max_concurrency: 3
-    always_run: false
-    skip_report: false
-    pipeline_run_spec:
-      pipelineRef:
-        name: aws
-      serviceAccountName: test-runs
-      timeout: 5h0m0s
-      resources:
-        - name: releases
-          resourceRef:
-            name: PROW_IMPLICIT_GIT_REF
-      workspaces:
-        - name: cluster
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Mi
-    trigger: "/test aws"
-    rerun_command: "/test aws"
   - name: aws-china
     agent: tekton-pipeline
     max_concurrency: 3
@@ -142,6 +117,31 @@ presubmits:
                   storage: 10Mi
     trigger: "/test aws-china"
     rerun_command: "/test aws-china"
+  - name: aws
+    agent: tekton-pipeline
+    max_concurrency: 3
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: aws
+      serviceAccountName: test-runs
+      timeout: 5h0m0s
+      resources:
+        - name: releases
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test aws"
+    rerun_command: "/test aws"
   - name: azure
     agent: tekton-pipeline
     max_concurrency: 5

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -92,6 +92,31 @@ presubmits:
                 storage: 10Mi
     trigger: "/test cncf"
     rerun_command: "/test cncf"
+  - name: aws
+    agent: tekton-pipeline
+    max_concurrency: 3
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: aws
+      serviceAccountName: test-runs
+      timeout: 5h0m0s
+      resources:
+        - name: releases
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test aws$"
+    rerun_command: "/test aws"
   - name: aws-china
     agent: tekton-pipeline
     max_concurrency: 3
@@ -117,31 +142,6 @@ presubmits:
                   storage: 10Mi
     trigger: "/test aws-china"
     rerun_command: "/test aws-china"
-  - name: aws
-    agent: tekton-pipeline
-    max_concurrency: 3
-    always_run: false
-    skip_report: false
-    pipeline_run_spec:
-      pipelineRef:
-        name: aws
-      serviceAccountName: test-runs
-      timeout: 5h0m0s
-      resources:
-        - name: releases
-          resourceRef:
-            name: PROW_IMPLICIT_GIT_REF
-      workspaces:
-        - name: cluster
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Mi
-    trigger: "/test aws"
-    rerun_command: "/test aws"
   - name: azure
     agent: tekton-pipeline
     max_concurrency: 5

--- a/secrets/generate-standup-kubeconfig-secret.sh
+++ b/secrets/generate-standup-kubeconfig-secret.sh
@@ -2,7 +2,7 @@
 
 declare -A provider_installations
 provider_installations[aws]=gaia
-provider_installations[aws_china]=giraffe
+provider_installations[aws-china]=giraffe
 provider_installations[azure]=godsmack
 provider_installations[kvm]=gorgoth
 
@@ -16,7 +16,7 @@ function cleanup() {
 trap cleanup EXIT
 
 for service_account in "test-infra" "sonobuoy"; do
-  for provider in aws aws_china azure kvm; do
+  for provider in aws aws-china azure kvm; do
       installation=${provider_installations[$provider]}
       echo "creating $provider kubeconfig for $service_account in $installation"
 
@@ -67,7 +67,7 @@ for service_account in "test-infra" "sonobuoy"; do
       kubectl create secret generic standup-kubeconfig \
         -n test-workloads \
         --from-file=aws="$tmp_dir/aws-kubeconfig-$service_account" \
-        --from-file=aws_china="$tmp_dir/aws_china-kubeconfig-$service_account" \
+        --from-file=aws-china="$tmp_dir/aws-china-kubeconfig-$service_account" \
         --from-file=azure="$tmp_dir/azure-kubeconfig-$service_account" \
         --from-file=kvm="$tmp_dir/kvm-kubeconfig-$service_account" \
         --dry-run=client -o yaml \
@@ -77,7 +77,7 @@ for service_account in "test-infra" "sonobuoy"; do
     kubectl create secret generic $service_account-kubeconfig \
       -n test-workloads \
       --from-file=aws="$tmp_dir/aws-kubeconfig-$service_account" \
-      --from-file=aws_china="$tmp_dir/aws_china-kubeconfig-$service_account" \
+      --from-file=aws-china="$tmp_dir/aws-china-kubeconfig-$service_account" \
       --from-file=azure="$tmp_dir/azure-kubeconfig-$service_account" \
       --from-file=kvm="$tmp_dir/kvm-kubeconfig-$service_account" \
       --dry-run=client -o yaml \

--- a/secrets/generate-standup-kubeconfig-secret.sh
+++ b/secrets/generate-standup-kubeconfig-secret.sh
@@ -2,6 +2,7 @@
 
 declare -A provider_installations
 provider_installations[aws]=gaia
+provider_installations[aws_china]=giraffe
 provider_installations[azure]=godsmack
 provider_installations[kvm]=gorgoth
 
@@ -15,7 +16,7 @@ function cleanup() {
 trap cleanup EXIT
 
 for service_account in "test-infra" "sonobuoy"; do
-  for provider in aws azure kvm; do
+  for provider in aws aws_china azure kvm; do
       installation=${provider_installations[$provider]}
       echo "creating $provider kubeconfig for $service_account in $installation"
 
@@ -66,6 +67,7 @@ for service_account in "test-infra" "sonobuoy"; do
       kubectl create secret generic standup-kubeconfig \
         -n test-workloads \
         --from-file=aws="$tmp_dir/aws-kubeconfig-$service_account" \
+        --from-file=aws_china="$tmp_dir/aws_china-kubeconfig-$service_account" \
         --from-file=azure="$tmp_dir/azure-kubeconfig-$service_account" \
         --from-file=kvm="$tmp_dir/kvm-kubeconfig-$service_account" \
         --dry-run=client -o yaml \
@@ -75,6 +77,7 @@ for service_account in "test-infra" "sonobuoy"; do
     kubectl create secret generic $service_account-kubeconfig \
       -n test-workloads \
       --from-file=aws="$tmp_dir/aws-kubeconfig-$service_account" \
+      --from-file=aws_china="$tmp_dir/aws_china-kubeconfig-$service_account" \
       --from-file=azure="$tmp_dir/azure-kubeconfig-$service_account" \
       --from-file=kvm="$tmp_dir/kvm-kubeconfig-$service_account" \
       --dry-run=client -o yaml \

--- a/tekton/pipelines/apps.yaml
+++ b/tekton/pipelines/apps.yaml
@@ -14,6 +14,9 @@ spec:
       type: string
   tasks:
     - name: create-release
+      params:
+      - name: pipeline-name
+        value: "$(context.pipeline.name)"
       taskRef:
         name: create-release
       workspaces:

--- a/tekton/pipelines/aws-china.yaml
+++ b/tekton/pipelines/aws-china.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/aws-china.yaml
+++ b/tekton/pipelines/aws-china.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: aws_china
+  name: aws-china
   namespace: test-workloads
 spec:
   resources:
@@ -28,7 +28,7 @@ spec:
     runAfter: [create-release]
     timeout: 2h0m0s
     taskRef:
-      name: aws_china
+      name: aws-china
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/aws_china.yaml
+++ b/tekton/pipelines/aws_china.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: aws_china
+  namespace: test-workloads
+spec:
+  resources:
+  - name: releases
+    type: git
+  workspaces:
+  - name: cluster
+  params:
+  - name: PROW_JOB_ID
+    type: string
+  tasks:
+  - name: create-release
+    taskRef:
+      name: create-release
+    workspaces:
+    - name: cluster
+      workspace: cluster
+    resources:
+      inputs:
+      - name: releases
+        resource: releases
+
+  - name: test-aws-china
+    runAfter: [create-release]
+    timeout: 2h0m0s
+    taskRef:
+      name: aws_china
+    workspaces:
+    - name: cluster
+      workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -14,6 +14,9 @@ spec:
     type: string
   tasks:
   - name: create-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-release
     workspaces:

--- a/tekton/pipelines/kustomization.yaml
+++ b/tekton/pipelines/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - apps.yaml
 - aws.yaml
-- aws_china.yaml
+- aws-china.yaml
 - azure.yaml
 - cis.yaml
 - cncf.yaml

--- a/tekton/pipelines/kustomization.yaml
+++ b/tekton/pipelines/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - apps.yaml
 - aws.yaml
+- aws_china.yaml
 - azure.yaml
 - cis.yaml
 - cncf.yaml

--- a/tekton/pipelines/upgrade-to-this-azure-operator.yaml
+++ b/tekton/pipelines/upgrade-to-this-azure-operator.yaml
@@ -16,6 +16,9 @@ spec:
     type: string
   tasks:
   - name: create-test-operator-release
+    params:
+    - name: pipeline-name
+      value: "$(context.pipeline.name)"
     taskRef:
       name: create-test-operator-release
     workspaces:

--- a/tekton/tasks/aws-china.yaml
+++ b/tekton/tasks/aws-china.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: aws_china
+  name: aws-china
   namespace: test-workloads
 spec:
   volumes:
@@ -20,7 +20,7 @@ spec:
       script: |
         #! /bin/sh
         
-        export AWSCNFM_CONTROLPLANE_KUBECONFIG=/etc/controlplane/aws_china
+        export AWSCNFM_CONTROLPLANE_KUBECONFIG=/etc/controlplane/aws-china
         export AWSCNFM_CREATE_RELEASEVERSION=$(cat $(workspaces.cluster.path)/release-id)
         
         awscnfm plan pl001

--- a/tekton/tasks/aws_china.yaml
+++ b/tekton/tasks/aws_china.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: aws_china
+  namespace: test-workloads
+spec:
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: standup-kubeconfig
+  workspaces:
+    - name: cluster
+      description: In China, run the aws conformance test plan of the most basic cluster scope in order to cover cluster creation and deletion.
+  steps:
+    - name: run-tests
+      image: quay.io/giantswarm/awscnfm:15.0.2
+      volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/controlplane
+      script: |
+        #! /bin/sh
+        
+        export AWSCNFM_CONTROLPLANE_KUBECONFIG=/etc/controlplane/aws_china
+        export AWSCNFM_CREATE_RELEASEVERSION=$(cat $(workspaces.cluster.path)/release-id)
+        
+        awscnfm plan pl001

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -30,5 +30,5 @@ spec:
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
       --cluster $(cat $(workspaces.cluster.path)/cluster-id) \
-      --provider $(cat $(workspaces.cluster.path)/provider) \
+      --installation $(cat $(workspaces.cluster.path)/installation) \
       --release $(cat $(workspaces.cluster.path)/release-id)

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/cleanup.yaml
+++ b/tekton/tasks/cleanup.yaml
@@ -18,7 +18,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -25,7 +25,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -25,7 +25,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -25,7 +25,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -37,7 +37,7 @@ spec:
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
       --release $(params.release-id) \
-      --provider $(cat $(workspaces.cluster.path)/provider) \
+      --installation $(cat $(workspaces.cluster.path)/installation) \
       --output $(workspaces.cluster.path)
 
       cat $(workspaces.cluster.path)/cluster-id > $(results.cluster-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -47,6 +47,7 @@ spec:
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
-      --output $(workspaces.cluster.path)
+      --output $(workspaces.cluster.path) \
+      --task $(context.taskRun.name)
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -35,12 +35,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     env:
       - name: PIPELINE_NAME
         value: $(params.pipeline-name)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -46,11 +46,12 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
+      echo $TASK_NAME
       standup create release \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path) \
-      --task $TASK_NAME
+      --task "${TASK_NAME}"
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -56,6 +56,6 @@ spec:
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path) \
-      --task "${PIPELINE_NAME}"
+      --pipeline "${PIPELINE_NAME}"
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -35,12 +35,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     env:
       - name: PIPELINE_NAME
         value: $(params.pipeline-name)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/name: "standup"
 spec:
+  params:
+    - name: pipeline-name
+      type: string
+      description: Name of the pipeline running this task.
   resources:
     inputs:
     - name: releases
@@ -37,8 +41,8 @@ spec:
   - name: create-release
     image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     env:
-      - name: TASK_NAME
-        value: $(context.task.name)
+      - name: PIPELINE_NAME
+        value: $(params.pipeline-name)
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -46,12 +50,12 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      echo $TASK_NAME
+      echo $PIPELINE_NAME
       standup create release \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path) \
-      --task "${TASK_NAME}"
+      --task "${PIPELINE_NAME}"
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -9,6 +9,7 @@ spec:
   params:
     - name: pipeline-name
       type: string
+      default: "generic"
       description: Name of the pipeline running this task.
   resources:
     inputs:
@@ -50,7 +51,6 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      echo $PIPELINE_NAME
       standup create release \
       --config /etc/endpoints-config/config \
       --kubeconfig /etc/kubeconfig \

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -36,6 +36,9 @@ spec:
       runAsGroup: 0
   - name: create-release
     image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    env:
+      - name: TASK_NAME
+        value: $(context.task.name)
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -48,6 +51,6 @@ spec:
       --kubeconfig /etc/kubeconfig \
       --releases /workspace/releases \
       --output $(workspaces.cluster.path) \
-      --task $(context.taskRun.name)
+      --task $TASK_NAME
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-release.yaml
+++ b/tekton/tasks/create-release.yaml
@@ -30,12 +30,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-release
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -32,12 +32,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-test-operator-release
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -36,12 +36,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-test-operator-release
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     env:
       - name: PIPELINE_NAME
         value: $(params.pipeline-name)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -38,6 +38,9 @@ spec:
       runAsGroup: 0
   - name: create-test-operator-release
     image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    env:
+      - name: TASK_NAME
+        value: $(context.task.name)
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -52,6 +55,6 @@ spec:
       --releases-path /workspace/releases \
       --output $(workspaces.cluster.path) \
       --provider azure \
-      --task $(context.taskRun.name)
+      --task $TASK_NAME
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/name: "standup"
 spec:
+  params:
+    - name: pipeline-name
+      type: string
+      description: Name of the pipeline running this task.
   resources:
     inputs:
     - name: releases
@@ -39,8 +43,8 @@ spec:
   - name: create-test-operator-release
     image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     env:
-      - name: TASK_NAME
-        value: $(context.task.name)
+      - name: PIPELINE_NAME
+        value: $(params.pipeline-name)
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -55,6 +59,6 @@ spec:
       --releases-path /workspace/releases \
       --output $(workspaces.cluster.path) \
       --provider azure \
-      --task $TASK_NAME
+      --task $PIPELINE_NAME
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -59,6 +59,6 @@ spec:
       --releases-path /workspace/releases \
       --output $(workspaces.cluster.path) \
       --provider azure \
-      --task $PIPELINE_NAME
+      --pipeline $PIPELINE_NAME
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -51,6 +51,7 @@ spec:
       --operator-path /workspace/azure-operator \
       --releases-path /workspace/releases \
       --output $(workspaces.cluster.path) \
-      --provider azure
+      --provider azure \
+      --task $(context.taskRun.name)
 
       cat $(workspaces.cluster.path)/release-id > $(results.release-id.path)

--- a/tekton/tasks/create-test-operator-release.yaml
+++ b/tekton/tasks/create-test-operator-release.yaml
@@ -36,12 +36,12 @@ spec:
     - -R
     - 1000:1000
     - /workspace
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     securityContext:
       runAsUser: 0
       runAsGroup: 0
   - name: create-test-operator-release
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     env:
       - name: PIPELINE_NAME
         value: $(params.pipeline-name)

--- a/tekton/tasks/get-latest-release.yaml
+++ b/tekton/tasks/get-latest-release.yaml
@@ -22,7 +22,7 @@ spec:
     description: The ID of the latest release.
   steps:
   - name: get-latest-release
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/get-latest-release.yaml
+++ b/tekton/tasks/get-latest-release.yaml
@@ -22,7 +22,7 @@ spec:
     description: The ID of the latest release.
   steps:
   - name: get-latest-release
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/get-latest-release.yaml
+++ b/tekton/tasks/get-latest-release.yaml
@@ -22,7 +22,7 @@ spec:
     description: The ID of the latest release.
   steps:
   - name: get-latest-release
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/kubectl-gs.yaml
+++ b/tekton/tasks/kubectl-gs.yaml
@@ -36,7 +36,7 @@ spec:
     description: Minimum number of worker nodes for the node pool.
   steps:
   - name: render-cluster-manifests
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/kubectl-gs.yaml
+++ b/tekton/tasks/kubectl-gs.yaml
@@ -36,7 +36,7 @@ spec:
     description: Minimum number of worker nodes for the node pool.
   steps:
   - name: render-cluster-manifests
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/kubectl-gs.yaml
+++ b/tekton/tasks/kubectl-gs.yaml
@@ -36,7 +36,7 @@ spec:
     description: Minimum number of worker nodes for the node pool.
   steps:
   - name: render-cluster-manifests
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - apps.yaml
 - aws.yaml
-- aws_china.yaml
+- aws-china.yaml
 - azure.yaml
 - cis.yaml
 - cleanup.yaml

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - apps.yaml
 - aws.yaml
+- aws_china.yaml
 - azure.yaml
 - cis.yaml
 - cleanup.yaml

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     description: Release ID that the cluster will be upgraded to.
   steps:
   - name: upgrade-cluster
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     description: Release ID that the cluster will be upgraded to.
   steps:
   - name: upgrade-cluster
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig

--- a/tekton/tasks/upgrade-cluster.yaml
+++ b/tekton/tasks/upgrade-cluster.yaml
@@ -23,7 +23,7 @@ spec:
     description: Release ID that the cluster will be upgraded to.
   steps:
   - name: upgrade-cluster
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -20,7 +20,7 @@ spec:
     description: Kubeconfig path for the cluster where sonobuoy will run.
   steps:
     - name: wait-for-condition-ready
-      image: quay.io/giantswarm/standup:2.7.0
+      image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
       volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kubeconfig

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -20,7 +20,7 @@ spec:
     description: Kubeconfig path for the cluster where sonobuoy will run.
   steps:
     - name: wait-for-condition-ready
-      image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+      image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
       volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kubeconfig

--- a/tekton/tasks/wait-for-condition-ready.yaml
+++ b/tekton/tasks/wait-for-condition-ready.yaml
@@ -20,7 +20,7 @@ spec:
     description: Kubeconfig path for the cluster where sonobuoy will run.
   steps:
     - name: wait-for-condition-ready
-      image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+      image: quay.io/giantswarm/standup:3.0.0
       volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kubeconfig

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
+    image: quay.io/giantswarm/standup:3.0.0
     script: |
       #! /bin/sh
       standup wait \

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:2.7.0
+    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
     script: |
       #! /bin/sh
       standup wait \

--- a/tekton/tasks/wait-for-ready.yaml
+++ b/tekton/tasks/wait-for-ready.yaml
@@ -11,7 +11,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: wait-for-ready
-    image: quay.io/giantswarm/standup:2.7.0-92a782a3bd4beb761759784b5d8aba7589500b0e
+    image: quay.io/giantswarm/standup:2.7.0-f6cbffe2c7f94b247320f16da95f55f20f380cb3
     script: |
       #! /bin/sh
       standup wait \


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17919

Adds the `/test aws-china` trigger and associated `aws-china` Tekton resources to run AWS tests in China.