### PR TITLE
Cleanup AWS release

### DIFF
--- a/tekton/pipelines/aws-china.yaml
+++ b/tekton/pipelines/aws-china.yaml
@@ -35,3 +35,11 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
+
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+      - name: cluster
+        workspace: cluster

--- a/tekton/pipelines/aws.yaml
+++ b/tekton/pipelines/aws.yaml
@@ -35,3 +35,11 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
+
+  finally:
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    workspaces:
+      - name: cluster
+        workspace: cluster


### PR DESCRIPTION
I think this should do the trick cleaning up our releases when running AWS cnfm tests. Even awscnfm is already deleting the cluster, standup should be still able to delete the release (should fall through if cluster is already deleted from observing the code).