### PR TITLE
Update sonobuoy to v0.52.0

### DIFF
--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -14,7 +14,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: sonobuoy/sonobuoy:v0.20.0
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
       env:
         - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -14,7 +14,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
       env:
         - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -14,7 +14,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
       env:
         - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id

--- a/tekton/tasks/apps.yaml
+++ b/tekton/tasks/apps.yaml
@@ -14,7 +14,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
+      image: quay.io/giantswarm/sonobuoy:v0.52.0-alpine-giantswarm
       env:
         - name: "CLUSTER_ID_PATH"
           value: $(workspaces.cluster.path)/cluster-id

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -22,7 +22,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
       env:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -22,7 +22,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: sonobuoy/sonobuoy:v0.20.0
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
       env:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -22,7 +22,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
       env:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/azure.yaml
+++ b/tekton/tasks/azure.yaml
@@ -22,7 +22,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/master/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
+      image: quay.io/giantswarm/sonobuoy:v0.52.0-alpine-giantswarm
       env:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cis.yaml
+++ b/tekton/tasks/cis.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: sonobuoy/sonobuoy:v0.20.0
+    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cis.yaml
+++ b/tekton/tasks/cis.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
+    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cis.yaml
+++ b/tekton/tasks/cis.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
+    image: quay.io/giantswarm/sonobuoy:v0.52.0-alpine-giantswarm
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cncf.yaml
+++ b/tekton/tasks/cncf.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
+    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cncf.yaml
+++ b/tekton/tasks/cncf.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: sonobuoy/sonobuoy:v0.20.0
+    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cncf.yaml
+++ b/tekton/tasks/cncf.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
+    image: quay.io/giantswarm/sonobuoy:v0.52.0-alpine-giantswarm
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cncf.yaml
+++ b/tekton/tasks/cncf.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
+    image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/kustomization.yaml
+++ b/tekton/tasks/kustomization.yaml
@@ -10,5 +10,11 @@ resources:
 - cncf.yaml
 - create-cluster.yaml
 - create-release.yaml
+- create-test-operator-release.yaml
+- generate-workload-cluster-kubeconfig.yaml
+- get-latest-release.yaml
+- manage-sonobuoy-results.yaml
+- upgrade-cluster.yaml
 - upload-to-s3-bucket.yaml
+- wait-for-condition-ready.yaml
 - wait-for-ready.yaml

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -21,7 +21,7 @@ spec:
       default: "sonobuoy"
   steps:
     - name: manage-sonobuoy-results
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
       script: |
         #! /bin/sh
 

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -28,19 +28,29 @@ spec:
         set -e
 
         cleanup() {
+          echo trapped
           /sonobuoy delete --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" --all --wait || true
         }
 
         trap cleanup INT TERM EXIT
 
+        echo status:
         /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)"
 
+        echo Retrieving: /sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)"
         outfile=$(/sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)")
+
+        echo "$outfile" results:
         /sonobuoy results "$outfile"
+
+        echo "$outfile" detailed results:
         /sonobuoy results "$outfile" --mode detailed
+
+        echo moving $outfile to "$(params.results-path)" AKA $(params.results-path)
         mv "$outfile" "$(params.results-path)"
 
         if /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" | grep failed >/dev/null; then
+          echo failed
           exit 1
         fi
       volumeMounts:

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -21,7 +21,7 @@ spec:
       default: "sonobuoy"
   steps:
     - name: manage-sonobuoy-results
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-c9ca8ce9fecc3577efcad9f1d3edba3d984a4821
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
       script: |
         #! /bin/sh
 

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -40,7 +40,7 @@ spec:
         echo Retrieving: /sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)"
         outfile=$(/sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)")
 
-        echo "$outfile" results:
+        echo "$outfile" $outfile results:
         /sonobuoy results "$outfile"
 
         echo "$outfile" detailed results:

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -21,7 +21,7 @@ spec:
       default: "sonobuoy"
   steps:
     - name: manage-sonobuoy-results
-      image: sonobuoy/sonobuoy:v0.20.0
+      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-234dc078a0eb416cf9343ff8097f23a8bd67debf
       script: |
         #! /bin/sh
 

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -21,7 +21,7 @@ spec:
       default: "sonobuoy"
   steps:
     - name: manage-sonobuoy-results
-      image: quay.io/giantswarm/sonobuoy-alpine:0.0.0-9f1ef327f35d0b5cc5b06aae15783a7b93629075
+      image: quay.io/giantswarm/sonobuoy:v0.52.0-alpine-giantswarm
       script: |
         #! /bin/sh
 

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -28,29 +28,25 @@ spec:
         set -e
 
         cleanup() {
-          echo trapped
           /sonobuoy delete --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" --all --wait || true
         }
 
         trap cleanup INT TERM EXIT
 
-        echo status:
         /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)"
 
-        echo Retrieving: /sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)"
+        echo Retrieving logs...
         outfile=$(/sonobuoy retrieve --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)")
+        echo Results saved to $outfile
 
-        echo "$outfile" $outfile results:
+        echo Results:
         /sonobuoy results "$outfile"
-
-        echo "$outfile" detailed results:
         /sonobuoy results "$outfile" --mode detailed
 
-        echo moving $outfile to "$(params.results-path)" AKA $(params.results-path)
         mv "$outfile" "$(params.results-path)"
 
         if /sonobuoy status --namespace "$(params.sonobuoy-namespace)" --kubeconfig "$(params.kubeconfig-path)" | grep failed >/dev/null; then
-          echo failed
+          echo Found failed tests in sonobuoy status
           exit 1
         fi
       volumeMounts:


### PR DESCRIPTION
Updates sonobuoy and uses our alpine-based retagger-built image instead of upstream distroless image. 
Related: https://github.com/vmware-tanzu/sonobuoy/issues/1361