### PR TITLE
Use different plugin branch depending on pipeline

### DIFF
--- a/tekton/pipelines/azure-operator.yaml
+++ b/tekton/pipelines/azure-operator.yaml
@@ -60,6 +60,8 @@ spec:
     params:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
+    - name: plugin-branch
+      value: "legacy"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure-upgrade.yaml
+++ b/tekton/pipelines/azure-upgrade.yaml
@@ -85,6 +85,8 @@ spec:
     params:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
+    - name: plugin-branch
+      value: "legacy"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/azure.yaml
+++ b/tekton/pipelines/azure.yaml
@@ -55,7 +55,7 @@ spec:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
     - name: plugin-branch
-      value: "master"
+      value: "legacy"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/capz.yaml
+++ b/tekton/pipelines/capz.yaml
@@ -60,7 +60,7 @@ spec:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
     - name: plugin-branch
-      value: "capz-support"
+      value: "master"
     workspaces:
     - name: cluster
       workspace: cluster

--- a/tekton/pipelines/debug-azure.yaml
+++ b/tekton/pipelines/debug-azure.yaml
@@ -48,6 +48,8 @@ spec:
     params:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
+    - name: plugin-branch
+      value: "legacy"
     - name: test-deletion
       value: "0"
     workspaces:

--- a/tekton/pipelines/upgrade-to-this-azure-operator.yaml
+++ b/tekton/pipelines/upgrade-to-this-azure-operator.yaml
@@ -89,6 +89,8 @@ spec:
     params:
     - name: kubeconfig-path
       value: "/etc/kubeconfig/azure"
+    - name: plugin-branch
+      value: "legacy"
     workspaces:
     - name: cluster
       workspace: cluster


### PR DESCRIPTION
They `legacy` branch uses [this plugin branch](https://github.com/giantswarm/sonobuoy-plugin/blob/legacy/giantswarm-plugin.yaml#L6). It's the same code as it's in the `master` branch right now, with the only difference of using the `legacy` docker image from the plugin configuration file.

After we merge [this PR](https://github.com/giantswarm/sonobuoy-plugin/pull/49), the `master` branch and the `latest` docker tag will be for `capz`, while `legacy` will be for legacy GS clusters.