### PR TITLE
Change commands to trigger azure pipelines

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -165,8 +165,8 @@ presubmits:
               resources:
                 requests:
                   storage: 10Mi
-    trigger: "/test azure"
-    rerun_command: "/test azure"
+    trigger: "/test azure$"
+    rerun_command: "/test azure$"
   - name: aws-e2e
     agent: tekton-pipeline
     max_concurrency: 5
@@ -242,8 +242,8 @@ presubmits:
               resources:
                 requests:
                   storage: 10Mi
-    trigger: "/test upgrade-azure"
-    rerun_command: "/test upgrade-azure"
+    trigger: "/test azure-upgrade$"
+    rerun_command: "/test azure-upgrade$"
 
   - name: upgrade-to-this-azure-operator
     agent: tekton-pipeline


### PR DESCRIPTION
Using the mighty power of regex we can now use `/test azure` to trigger *only the azure e2e tests*. Similarly, `/test azure-upgrade` should only trigger the upgrade tests. So after merging this, no more `/test upgrade-azure`.