### PR TITLE
Upgrade kubectl-gs, which needs permissions to access secrets due to SSH

### DIFF
--- a/prow/cluster/test-workloads.yaml
+++ b/prow/cluster/test-workloads.yaml
@@ -24,6 +24,20 @@ rules:
     verbs:
       - "*"
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-workloads
+  name: secret-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - get
+      - list
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -33,6 +47,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-manager
+subjects:
+  - kind: ServiceAccount
+    name: test-runs
+    namespace: test-workloads
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-workloads
+  name: secret-manager-test-runs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secret-manager
 subjects:
   - kind: ServiceAccount
     name: test-runs

--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -50,7 +50,7 @@ spec:
       cat $(workspaces.cluster.path)/cluster-id > $(results.cluster-id.path)
 
   - name: create-cluster-capi
-    image: quay.io/giantswarm/kubectl-gs:1.40.0
+    image: quay.io/giantswarm/kubectl-gs:1.43.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config


### PR DESCRIPTION
[This change](https://github.com/giantswarm/kubectl-gs/pull/501/files#diff-7ed39ff1e031ba7320a6deba88ecc23957e78857828c660c3aee1d99f855f291R19) makes the ServiceAccount used to run the test to need permissions to read Secrets.