### PR TITLE
update awscnfm and drop trigger apps

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -17,31 +17,6 @@ deck:
 
 presubmits:
   giantswarm/releases:
-  - name: apps
-    agent: tekton-pipeline
-    max_concurrency: 3
-    always_run: false
-    skip_report: false
-    pipeline_run_spec:
-      pipelineRef:
-        name: apps
-      serviceAccountName: test-runs
-      timeout: 5h0m0s
-      resources:
-        - name: releases
-          resourceRef:
-            name: PROW_IMPLICIT_GIT_REF
-      workspaces:
-        - name: cluster
-          volumeClaimTemplate:
-            spec:
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 10Mi
-    trigger: "/test apps"
-    rerun_command: "/test apps"
   - name: cis
     agent: tekton-pipeline
     max_concurrency: 3

--- a/tekton/tasks/aws-china.yaml
+++ b/tekton/tasks/aws-china.yaml
@@ -13,7 +13,7 @@ spec:
       description: In China, run the aws conformance test plan of the most basic cluster scope in order to cover cluster creation and deletion.
   steps:
     - name: run-tests
-      image: quay.io/giantswarm/awscnfm:15.2.0
+      image: quay.io/giantswarm/awscnfm:16.0.0
       volumeMounts:
         - name: kubeconfig
           mountPath: /etc/controlplane

--- a/tekton/tasks/aws.yaml
+++ b/tekton/tasks/aws.yaml
@@ -13,7 +13,7 @@ spec:
       description: Run the aws conformance test plan of the most basic cluster scope in order to cover cluster creation and deletion.
   steps:
     - name: run-tests
-      image: quay.io/giantswarm/awscnfm:15.2.0
+      image: quay.io/giantswarm/awscnfm:16.0.0
       volumeMounts:
         - name: kubeconfig
           mountPath: /etc/controlplane


### PR DESCRIPTION
I just noticed `/test apps` is not working anymore due to https://github.com/giantswarm/test-infra/pull/148/. I guess this was a leftover 🙂.

This also bumps awscnfm to support org namespaces 🎉.
