### PR TITLE
Export KUBECONFIG and upgrade kubectl-gs

### DIFF
--- a/tekton/tasks/create-cluster.yaml
+++ b/tekton/tasks/create-cluster.yaml
@@ -50,7 +50,7 @@ spec:
       cat $(workspaces.cluster.path)/cluster-id > $(results.cluster-id.path)
 
   - name: create-cluster-capi
-    image: quay.io/giantswarm/kubectl-gs:1.43.0
+    image: quay.io/giantswarm/kubectl-gs:1.43.1
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config
@@ -67,6 +67,8 @@ spec:
         echo "Release $(params.release-id) is not a CAPI release"
         exit 0
       fi
+
+      export KUBECONFIG=/etc/kubeconfig/$(cat $(workspaces.cluster.path)/installation)
 
       # Generate template for control plane.
       kubectl-gs template cluster \
@@ -93,7 +95,6 @@ spec:
         --nodes-max 10 \
         --output /tmp/nodepool.yaml
 
-      export KUBECONFIG=/etc/kubeconfig/$(cat $(workspaces.cluster.path)/installation)
       cat /tmp/cluster.yaml | kubectl apply -f -
       cat /tmp/nodepool.yaml | kubectl apply -f -
 


### PR DESCRIPTION
After the fix we did last week, we need the `KUBECONFIG` env var to be exported so that `kubectl-gs` creates the right controller-runtime Client.