### PR TITLE
In `get-latest-release` skip capi version

### DIFF
--- a/tekton/tasks/get-latest-release.yaml
+++ b/tekton/tasks/get-latest-release.yaml
@@ -28,6 +28,6 @@ spec:
         mountPath: /etc/kubeconfig
     script: |
       #! /bin/sh
-      LATEST_STABLE_RELEASE=$(kubectl --kubeconfig $(params.kubeconfig-path) get releases -o json | jq -r '[.items | sort_by(.metadata.name) | reverse[] | select(.metadata.name | test("v[0-9]*\\.[0-9]*\\.[0-9]*$")) ][].metadata.name' | head -n1)
+      LATEST_STABLE_RELEASE=$(kubectl --kubeconfig $(params.kubeconfig-path) get releases -o json | jq -r '[.items | sort_by(.metadata.name) | reverse[] | select(.metadata.name | test("v1[0-9]*\\.[0-9]*\\.[0-9]*$")) ][].metadata.name' | head -n1)
 
       echo -n ${LATEST_STABLE_RELEASE} > $(results.release-id.path)


### PR DESCRIPTION
this is used by the upgrade test and we never run the upgrade test for capi clusters (yet) so it doesn't make sense to start a capi cluster and try to upgrade it to a non capi one.