### PR TITLE
Retry apply of cluster CRs

### DIFF
--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -79,6 +79,7 @@ spec:
         IFS="§"
         for yml in $data
         do
+          if [ "$yml" == "" ] ; do break; done
           ok="false"
           for i in $(seq 1 5); do
             echo "$yml" | kubectl apply -f -

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -75,18 +75,10 @@ spec:
       # This function splits a multi-document yaml file into single yaml manifests
       # and retries applying each manifest up to 5 times in case of failure.
       retry_single() {
-        x="$(cat $1)"
-        while [[ -n "$x" ]]
-        do
-          ary+=("${x%%---*}")
-          if [[ "$x" =~ --- ]]
-          then
-            x="${x#*---}"
-          else
-            x=''
-          fi
-        done
-        for yml in "${ary[@]}"
+       ; for token in `cat /tmp/release.yaml `; do echo $token; done
+        data="$(cat $1 | sed 's/---/§/g')"
+        IFS="§"
+        for yml in $data
         do
           ok="false"
           for i in $(seq 1 5); do

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -79,7 +79,7 @@ spec:
         IFS="§"
         for yml in $data
         do
-          if [ "$yml" == "" ] ; do continue; done
+          if [ "$yml" == "" ] ; then continue; done
           ok="false"
           for i in $(seq 1 5); do
             echo "$yml" | kubectl apply -f -

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -72,19 +72,6 @@ spec:
         --output /tmp/nodepool.yaml
 
       set +e
-      # Try applying the cluster YAML 5 times to support transient failures in the apply process.
-      ok="false"
-      for i in $(seq 1 5); do
-        cat /tmp/cluster.yaml | kubectl apply -f -
-        success=$?
-        if [ "$success" -eq "0" ]; then
-          ok="true"
-          break
-        fi
-
-        sleep 15
-      done
-
       # This function splits a multi-document yaml file into single yaml manifests
       # and retries applying each manifest up to 5 times in case of failure.
       retry_single() {

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -73,6 +73,7 @@ spec:
 
       set +e
       # Try applying the cluster YAML 5 times to support transient failures in the apply process.
+      ok="false"
       for i in $(seq 1 5); do
         cat /tmp/cluster.yaml | kubectl apply -f -
         success=$?
@@ -84,17 +85,42 @@ spec:
         sleep 15
       done
 
-      # Try applying the cluster YAML 5 times to support transient failures in the apply process.
-      for i in $(seq 1 5); do
-        cat /tmp/nodepool.yaml | kubectl apply -f -
-        success=$?
-        if [ "$success" -eq "0" ]; then
-          ok="true"
-          break
-        fi
+      # This function splits a multi-document yaml file into single yaml manifests
+      # and retries applying each manifest up to 5 times in case of failure.
+      retry_single() {
+        x="$(cat $1)"
+        while [[ -n "$x" ]]
+        do
+          ary+=("${x%%---*}")
+          if [[ "$x" =~ --- ]]
+          then
+            x="${x#*---}"
+          else
+            x=''
+          fi
+        done
+        for yml in "${ary[@]}"
+        do
+          ok="false"
+          for i in $(seq 1 5); do
+            echo "$yml" | kubectl apply -f -
+            success=$?
+            if [ "$success" -eq "0" ]; then
+              ok="true"
+              break
+            fi
+          done
 
-        sleep 15
-      done
+          if [ "$ok" != "true" ]
+          then
+            echo "Failed to apply $1"
+            exit 1
+          fi
+        done
+      }
+
+      retry_single /tmp/cluster.yaml
+      retry_single /tmp/nodepool.yaml
 
   - name: legacy-get-kubeconfig
     image: quay.io/giantswarm/kubectl:1.22.3

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -79,7 +79,7 @@ spec:
         IFS="§"
         for yml in $data
         do
-          if [ "$yml" == "" ] ; do break; done
+          if [ "$yml" == "" ] ; do continue; done
           ok="false"
           for i in $(seq 1 5); do
             echo "$yml" | kubectl apply -f -

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -71,8 +71,30 @@ spec:
         $AZS \
         --output /tmp/nodepool.yaml
 
-      cat /tmp/cluster.yaml | kubectl apply -f -
-      cat /tmp/nodepool.yaml | kubectl apply -f -
+      set +e
+      # Try applying the cluster YAML 5 times to support transient failures in the apply process.
+      for i in $(seq 1 5); do
+        cat /tmp/cluster.yaml | kubectl apply -f -
+        success=$?
+        if [ "$success" -eq "0" ]; then
+          ok="true"
+          break
+        fi
+
+        sleep 15
+      done
+
+      # Try applying the cluster YAML 5 times to support transient failures in the apply process.
+      for i in $(seq 1 5); do
+        cat /tmp/nodepool.yaml | kubectl apply -f -
+        success=$?
+        if [ "$success" -eq "0" ]; then
+          ok="true"
+          break
+        fi
+
+        sleep 15
+      done
 
   - name: legacy-get-kubeconfig
     image: quay.io/giantswarm/kubectl:1.22.3

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -79,7 +79,7 @@ spec:
         IFS="§"
         for yml in $data
         do
-          if [ "$yml" == "" ] ; then continue; done
+          if [ "$yml" == "" ] ; then continue; fi
           ok="false"
           for i in $(seq 1 5); do
             echo "$yml" | kubectl apply -f -

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -75,7 +75,6 @@ spec:
       # This function splits a multi-document yaml file into single yaml manifests
       # and retries applying each manifest up to 5 times in case of failure.
       retry_single() {
-       ; for token in `cat /tmp/release.yaml `; do echo $token; done
         data="$(cat $1 | sed 's/---/§/g')"
         IFS="§"
         for yml in $data

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -81,8 +81,8 @@ spec:
         do
           if [ "$yml" == "" ] ; then continue; fi
           ok="false"
-          for i in $(seq 1 5); do
-            echo "$yml" | kubectl apply -f -
+          for i in 1 2 3 4 5; do
+            echo "$yml" | kubectl --request-timeout=30s apply -f -
             success=$?
             if [ "$success" -eq "0" ]; then
               ok="true"


### PR DESCRIPTION
Sometimes, while creating clusters, there might be some transient errors that would be probably overcome with a retry.
This PR adds a few retries to the cluster creating phase

Example error:

```
+ cat /tmp/cluster.yaml
+ kubectl apply -f -
[azurecluster.infrastructure.cluster.x-k8s.io/ix2cc](http://azurecluster.infrastructure.cluster.x-k8s.io/ix2cc) created
[cluster.cluster.x-k8s.io/ix2cc](http://cluster.cluster.x-k8s.io/ix2cc) created
[azuremachine.infrastructure.cluster.x-k8s.io/ix2cc-master-0](http://azuremachine.infrastructure.cluster.x-k8s.io/ix2cc-master-0) created
+ cat /tmp/nodepool.yaml
+ kubectl apply -f -
[spark.core.giantswarm.io/kvj2w](http://spark.core.giantswarm.io/kvj2w) created
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "[mutate.azuremachinepools.create.azure-admission-controller.giantswarm.io](http://mutate.azuremachinepools.create.azure-admission-controller.giantswarm.io/)": Post "[https://azure-admission-controller.giantswarm.svc:443/mutate/azuremachinepool/create?timeout=10s](https://azure-admission-controller.giantswarm.svc/mutate/azuremachinepool/create?timeout=10s)": context deadline exceeded
Error from server (BadRequest): error when creating "STDIN": admission webhook "[validate.machinepools.create.azure-admission-controller.giantswarm.io](http://validate.machinepools.create.azure-admission-controller.giantswarm.io/)" denied the request: azure machine pool not found error: AzureMachinePool has to be created before the related MachinePool
```