### PR TITLE
bump images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `sonobuoy` to v0.56.7-alpine-giantswarm.
+- Bump `kubectl-gs` to 2.14.0.
+
 ### Added
 
 - Initial release.

--- a/tekton/tasks/cis.yaml
+++ b/tekton/tasks/cis.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy:v0.56.2-alpine-giantswarm
+    image: quay.io/giantswarm/sonobuoy:v0.56.7-alpine-giantswarm
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/cleanup-capi-pure.yaml
+++ b/tekton/tasks/cleanup-capi-pure.yaml
@@ -13,7 +13,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/kubectl-gs:2.4.0
+    image: quay.io/giantswarm/kubectl-gs:2.14.0
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/cncf.yaml
+++ b/tekton/tasks/cncf.yaml
@@ -9,7 +9,7 @@ spec:
     description: Cluster information is stored here.
   steps:
   - name: run-tests
-    image: quay.io/giantswarm/sonobuoy:v0.56.2-alpine-giantswarm
+    image: quay.io/giantswarm/sonobuoy:v0.56.7-alpine-giantswarm
     env:
       - name: "KUBECONFIG_PATH"
         value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -23,7 +23,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.4.0
+    image: quay.io/giantswarm/kubectl-gs:2.14.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster-capi-pure.yaml
+++ b/tekton/tasks/create-cluster-capi-pure.yaml
@@ -72,7 +72,7 @@ spec:
       echo $app_flags > $(workspaces.cluster.path)/kubectl-gs-flags
 
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.4.0
+    image: quay.io/giantswarm/kubectl-gs:2.14.0
     env:
     - name: PROVIDER
       value: $(params.provider)

--- a/tekton/tasks/e2e.yaml
+++ b/tekton/tasks/e2e.yaml
@@ -29,7 +29,7 @@ spec:
         #! /bin/sh
         wget -O $(workspaces.cluster.path)/giantswarm-plugin.yaml https://raw.githubusercontent.com/giantswarm/sonobuoy-plugin/$(params.plugin-branch)/giantswarm-plugin.yaml
     - name: run-tests
-      image: quay.io/giantswarm/sonobuoy:v0.56.2-alpine-giantswarm
+      image: quay.io/giantswarm/sonobuoy:v0.56.7-alpine-giantswarm
       env:
         - name: TC_KUBECONFIG_PATH
           value: $(workspaces.cluster.path)/kubeconfig

--- a/tekton/tasks/manage-sonobuoy-results.yaml
+++ b/tekton/tasks/manage-sonobuoy-results.yaml
@@ -21,7 +21,7 @@ spec:
       default: "sonobuoy"
   steps:
     - name: manage-sonobuoy-results
-      image: quay.io/giantswarm/sonobuoy:v0.56.2-alpine-giantswarm
+      image: quay.io/giantswarm/sonobuoy:v0.56.7-alpine-giantswarm
       script: |
         #! /bin/sh
 


### PR DESCRIPTION
We need latest kubectl-gs image in order to generate working legacy clusters in azure