### PR TITLE
Added missing 'interceptors.yaml' entry in resources list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Included missing `interceptors.yaml` in Kustomization resources list
+
 ## [1.0.0] - 2022-06-22
 
 ### Changed

--- a/tekton/triggers/kustomization.yaml
+++ b/tekton/triggers/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - add-pr-body.yaml
   - eventlistener.yaml
   - ingress.yaml
+  - interceptors.yaml
   - rbac.yaml
   - triggerbinding.yaml
   - triggertemplate.yaml


### PR DESCRIPTION
I double checked the other directories too and this was the only one missing.