### PR TITLE
Escape backslash to fix prow config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Escape backslash to fix prow config.
+
 ## [1.2.0] - 2022-08-12
 
 ### Changed

--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -304,7 +304,7 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
 
   giantswarm/default-apps-openstack:
@@ -342,7 +342,7 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
 
   giantswarm/cluster-aws:
@@ -380,7 +380,7 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
 
   giantswarm/default-apps-aws:
@@ -418,7 +418,7 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
 
   giantswarm/cluster-gcp:
@@ -456,7 +456,7 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
 
   giantswarm/default-apps-gcp:
@@ -494,5 +494,5 @@ presubmits:
             resources:
               requests:
                 storage: 10Mi
-    trigger: "/test create(\s|$)"
+    trigger: "/test create(\\s|$)"
     rerun_command: "/test create"


### PR DESCRIPTION
`hook` was failing with

```
{"component":"hook","error":"error unmarshaling /etc/config/configs.yaml: error converting YAML to JSON: yaml: line 307: found unknown escape character","file":"prow/cmd/hook/main.go:105","func":"main.main","level":"fatal","msg":"Error starting config agent.","severity":"fatal","time":"2022-08-18T14:31:32Z"}
```