### PR TITLE
Add upgrade test for CAPI clusters

### DIFF
--- a/prow/configs.yaml
+++ b/prow/configs.yaml
@@ -382,6 +382,42 @@ presubmits:
                 storage: 10Mi
     trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
+  - name: upgrade
+    agent: tekton-pipeline
+    max_concurrency: 1
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: upgrade-cluster-capi-pure
+      serviceAccountName: test-runs
+      timeout: 3h0m0s
+      params:
+        - name: source-repo-name
+          value: cluster-aws
+        - name: provider
+          value: aws
+        - name: installation
+          value: gaia
+        - name: cluster-chart
+          value: cluster-aws
+        - name: default-apps-chart
+          value: default-apps-aws
+      resources:
+        - name: source-repo
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test upgrade(\\s|$)"
+    rerun_command: "/test upgrade"
 
   giantswarm/default-apps-aws:
   - name: create
@@ -420,6 +456,42 @@ presubmits:
                 storage: 10Mi
     trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
+  - name: upgrade
+    agent: tekton-pipeline
+    max_concurrency: 1
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: upgrade-cluster-capi-pure
+      serviceAccountName: test-runs
+      timeout: 3h0m0s
+      params:
+        - name: source-repo-name
+          value: default-apps-aws
+        - name: provider
+          value: aws
+        - name: installation
+          value: gaia
+        - name: cluster-chart
+          value: cluster-aws
+        - name: default-apps-chart
+          value: default-apps-aws
+      resources:
+        - name: source-repo
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test upgrade(\\s|$)"
+    rerun_command: "/test upgrade"
 
   giantswarm/cluster-gcp:
   - name: create
@@ -458,6 +530,42 @@ presubmits:
                 storage: 10Mi
     trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
+  - name: upgrade
+    agent: tekton-pipeline
+    max_concurrency: 1
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: upgrade-cluster-capi-pure
+      serviceAccountName: test-runs
+      timeout: 3h0m0s
+      params:
+        - name: source-repo-name
+          value: cluster-gcp
+        - name: provider
+          value: gcp
+        - name: installation
+          value: gunther
+        - name: cluster-chart
+          value: cluster-gcp
+        - name: default-apps-chart
+          value: default-apps-gcp
+      resources:
+        - name: source-repo
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test upgrade(\\s|$)"
+    rerun_command: "/test upgrade"
 
   giantswarm/default-apps-gcp:
   - name: create
@@ -496,3 +604,39 @@ presubmits:
                 storage: 10Mi
     trigger: "/test create(\\s|$)"
     rerun_command: "/test create"
+  - name: upgrade
+    agent: tekton-pipeline
+    max_concurrency: 1
+    always_run: false
+    skip_report: false
+    pipeline_run_spec:
+      pipelineRef:
+        name: upgrade-cluster-capi-pure
+      serviceAccountName: test-runs
+      timeout: 3h0m0s
+      params:
+        - name: source-repo-name
+          value: default-apps-gcp
+        - name: provider
+          value: gcp
+        - name: installation
+          value: gunther
+        - name: cluster-chart
+          value: cluster-gcp
+        - name: default-apps-chart
+          value: default-apps-gcp
+      resources:
+        - name: source-repo
+          resourceRef:
+            name: PROW_IMPLICIT_GIT_REF
+      workspaces:
+        - name: cluster
+          volumeClaimTemplate:
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Mi
+    trigger: "/test upgrade(\\s|$)"
+    rerun_command: "/test upgrade"

--- a/tekton/pipelines/upgrade-cluster-capi-pure.yaml
+++ b/tekton/pipelines/upgrade-cluster-capi-pure.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: create-cluster-capi-pure
+  name: upgrade-cluster-capi-pure
   namespace: test-workloads
 spec:
   resources:
@@ -42,7 +42,6 @@ spec:
       inputs:
       - name: source-repo
         resource: source-repo
-
   - name: create-cluster
     params:
     - name: source-repo-name
@@ -53,16 +52,16 @@ spec:
       value: $(params.installation)
     - name: cluster-chart
       value: $(params.cluster-chart)
+    - name: cluster-app-chart-version
+      value: ""
+    - name: cluster-app-catalog
+      value: "cluster"
     - name: default-apps-chart
       value: $(params.default-apps-chart)
-    - name: cluster-app-chart-version
-      value: $(tasks.calculate-versions.results.cluster-app-chart-version)
-    - name: cluster-app-catalog
-      value: $(tasks.calculate-versions.results.cluster-app-catalog)
     - name: default-apps-chart-version
-      value: $(tasks.calculate-versions.results.default-apps-chart-version)
+      value: ""
     - name: default-apps-catalog
-      value: $(tasks.calculate-versions.results.default-apps-catalog)
+      value: "cluster"
     taskRef:
       name: create-cluster-capi-pure
     workspaces:
@@ -81,6 +80,32 @@ spec:
     workspaces:
     - name: cluster
       workspace: cluster
+
+  - name: upgrade-cluster
+    runAfter: [wait-for-ready]
+    taskRef:
+      name: upgrade-cluster-capi-pure
+    params:
+    - name: cluster-id
+      value: "$(tasks.create-cluster.results.cluster-id)"
+    - name: cluster-app-chart-version
+      value: "$(tasks.calculate-versions.results.cluster-app-chart-version)"
+    - name: provider
+      value: $(params.provider)
+    - name: organization
+      value: "$(tasks.create-cluster.results.organization)"
+    workspaces:
+      - name: cluster
+        workspace: cluster
+
+  - name: wait-for-ready-after-upgrade
+    runAfter: [upgrade-cluster]
+    timeout: 1h0m0s
+    taskRef:
+      name: wait-for-ready
+    workspaces:
+      - name: cluster
+        workspace: cluster
 
   finally:
   - name: cleanup

--- a/tekton/tasks/calculate-versions.yaml
+++ b/tekton/tasks/calculate-versions.yaml
@@ -1,0 +1,90 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: calculate-versions
+  namespace: test-workloads
+spec:
+  params:
+  - name: source-repo-name
+    type: string
+  - name: provider
+    type: string
+  - name: installation
+    type: string
+  - name: cluster-chart
+    type: string
+  - name: default-apps-chart
+    type: string
+  volumes:
+  - name: kubeconfig
+    secret:
+      secretName: standup-kubeconfig
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  resources:
+    inputs:
+    - name: source-repo
+      type: git
+  results:
+  - name: cluster-id
+    description: The ID of the created cluster.
+  - name: organization
+    description: Organization that owns the cluster.
+  - name: cluster-app-chart-version
+    description: Version to use when installing the cluster app.
+  - name: cluster-app-catalog
+    description: Catalog to use when installing the cluster app.
+  - name: default-apps-chart-version
+    description: Version to use when installing default apps.
+  - name: default-apps-catalog
+    description: Catalog to use when installing the default apps app.
+  steps:
+  - name: chown-source-repo
+    command:
+    - chown
+    - -R
+    - 1000:1000
+    - /workspace/source-repo
+    image: quay.io/giantswarm/standup:3.2.0
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  - name: calculate-inputs
+    image: quay.io/giantswarm/standup:3.2.0
+    env:
+    - name: SOURCE_REPO_NAME
+      value: $(params.source-repo-name)
+    - name: INSTALLATION
+      value: $(params.installation)
+    - name: CLUSTER_CHART
+      value: $(params.cluster-chart)
+    - name: DEFAULT_APPS_CHART
+      value: $(params.default-apps-chart)
+    script: |
+      #! /bin/sh
+
+      set -e
+      set -x
+
+      cd /workspace/source-repo
+      git fetch --unshallow
+      parent_tag=$(git describe --tags --abbrev=0 | sed -e "s/^v//")
+      hash=$(git describe --always --abbrev=0)
+      repo_version=${parent_tag}-${hash}
+
+      if [ "$SOURCE_REPO_NAME" = "$DEFAULT_APPS_CHART" ]; then
+        app_flags="--default-apps-catalog cluster-test --default-apps-version $repo_version"
+        echo -n "" > $(results.cluster-app-chart-version.path)
+        echo -n "cluster" > $(results.cluster-app-catalog.path)
+        echo -n "${repo_version}" > $(results.default-apps-chart-version.path)
+        echo -n "cluster-test" > $(results.default-apps-catalog.path)
+      else
+        app_flags="--cluster-catalog cluster-test --cluster-version $repo_version"
+        echo -n "${repo_version}" > $(results.cluster-app-chart-version.path)
+        echo -n "cluster-test" > $(results.cluster-app-catalog.path)
+        echo -n "" > $(results.default-apps-chart-version.path)
+        echo -n "cluster" > $(results.default-apps-catalog.path)
+      fi
+
+      echo $app_flags > $(workspaces.cluster.path)/kubectl-gs-flags

--- a/tekton/tasks/create-cluster-capi-pure.yaml
+++ b/tekton/tasks/create-cluster-capi-pure.yaml
@@ -13,7 +13,15 @@ spec:
     type: string
   - name: cluster-chart
     type: string
+  - name: cluster-app-chart-version
+    type: string
+  - name: cluster-app-catalog
+    type: string
   - name: default-apps-chart
+    type: string
+  - name: default-apps-chart-version
+    type: string
+  - name: default-apps-catalog
     type: string
   volumes:
   - name: kubeconfig
@@ -32,52 +40,15 @@ spec:
   - name: organization
     description: Organization that owns the cluster.
   steps:
-  - name: chown-source-repo
-    command:
-    - chown
-    - -R
-    - 1000:1000
-    - /workspace/source-repo
-    image: quay.io/giantswarm/standup:3.2.0
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
-  - name: calculate-inputs
-    image: quay.io/giantswarm/standup:3.2.0
-    env:
-    - name: SOURCE_REPO_NAME
-      value: $(params.source-repo-name)
-    - name: INSTALLATION
-      value: $(params.installation)
-    - name: CLUSTER_CHART
-      value: $(params.cluster-chart)
-    - name: DEFAULT_APPS_CHART
-      value: $(params.default-apps-chart)
-    script: |
-      #! /bin/sh
-
-      set -e
-      set -x
-
-      cd /workspace/source-repo
-      git fetch --unshallow
-      parent_tag=$(git describe --tags --abbrev=0 | sed -e "s/^v//")
-      hash=$(git describe --always --abbrev=0)
-      repo_version=${parent_tag}-${hash}
-
-      if [ "$SOURCE_REPO_NAME" = "$DEFAULT_APPS_CHART" ]; then
-        app_flags="--default-apps-catalog cluster-test --default-apps-version $repo_version"
-      else
-        app_flags="--cluster-catalog cluster-test --cluster-version $repo_version"
-      fi
-
-      echo $app_flags > $(workspaces.cluster.path)/kubectl-gs-flags
-
   - name: create-cluster
     image: quay.io/giantswarm/kubectl-gs:2.16.0
     env:
     - name: PROVIDER
       value: $(params.provider)
+    - name: CLUSTER_APP_CHART_VERSION
+      value: $(params.cluster-app-chart-version)
+    - name: DEFAULT_APPS_CHART_VERSION
+      value: $(params.default-apps-chart-version)
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig
@@ -90,7 +61,15 @@ spec:
       export KUBECONFIG=/etc/kubeconfig/$PROVIDER
       cluster_id="t$(date +%s | cut -c7-10)"
       organization=giantswarm
-      extra_flags=$(cat $(workspaces.cluster.path)/kubectl-gs-flags)
+
+      extra_flags=""
+      if [ ! -z "$CLUSTER_APP_CHART_VERSION" ]; then
+        extra_flags="${extra_flags} --cluster-catalog cluster-test --cluster-version $CLUSTER_APP_CHART_VERSION"
+      fi
+
+      if [ ! -z "$DEFAULT_APPS_CHART_VERSION" ]; then
+        extra_flags="${extra_flags} --default-apps-catalog cluster-test --default-apps-version $DEFAULT_APPS_CHART_VERSION"
+      fi
 
       echo "generating template for cluster $cluster_id"
 

--- a/tekton/tasks/upgrade-cluster-capi-pure.yaml
+++ b/tekton/tasks/upgrade-cluster-capi-pure.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upgrade-cluster-capi-pure
+  namespace: test-workloads
+spec:
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: standup-kubeconfig
+  workspaces:
+  - name: cluster
+    description: Cluster information is stored here.
+  params:
+  - name: cluster-id
+    type: string
+    description: Cluster ID for the cluster that will be upgraded.
+  - name: provider
+    type: string
+  - name: organization
+    type: string
+  - name: cluster-app-chart-version
+    type: string
+    description: Version for the cluster app.
+  - name: cluster-app-catalog
+    type: string
+    default: cluster-test
+    description: App catalog to use for the cluster app.
+  steps:
+  - name: upgrade-cluster
+    image: quay.io/giantswarm/standup:3.2.0
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: /etc/kubeconfig
+    script: |
+      #! /bin/sh
+
+      set -eo pipefail
+      
+      echo "$(date): Upgrading cluster $(params.cluster-id) to $(params.cluster-app-chart-version)"
+      kubectl --kubeconfig /etc/kubeconfig/$(params.provider) patch apps -n org-$(params.organization) $(params.cluster-id) --type json -p '[{"op": "replace", "path": "/spec/version", "value": $(params.cluster-app-chart-version)}, {"op": "replace", "path": "/spec/catalog", "value": $(params.cluster-app-catalog)}]'
+
+      while [ `kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o json | jq -r '.status.version'` != "$(params.cluster-app-chart-version)" ] || [ `kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o json | jq -r '.status.release.status'` != "deployed" ]
+      do
+        echo "$(date): App for cluster '$(params.cluster-id)' still uses old version or has failed"
+        sleep 10
+      done


### PR DESCRIPTION
This adds a new test for CAPI clusters that covers the case of ugprading clusters.

It will create a cluster using the latest release available, and wait for it to be ready. Then it will patch the cluster `App` CR to upgrade it to the version that is being tested and wait for the `App` CR to have on its `status` fields the new version and don't be on a `failed` state.

We don't do much asserts after that, but I think this is useful to test helm issues while upgrading.