### PR TITLE
Fix eventlistener because in the current state the app fails to install

### DIFF
--- a/tekton/triggers/eventlistener.yaml
+++ b/tekton/triggers/eventlistener.yaml
@@ -26,29 +26,42 @@ spec:
         - kind: TriggerBinding
           ref: github-pr-binding
       interceptors:
-        - github:
-            eventTypes:
-              - issue_comment
-            secretRef:
-              secretKey: secretToken
-              secretName: github-secret
-        - cel:
-            filter: body.repository.full_name.startsWith('giantswarm/') &&
-              body.repository.name in ['sonobuoy-plugin'] &&
-              'pull_request' in body.issue &&
-              'url' in body.issue.pull_request &&
-              body.issue.state == 'open' &&
-              body.comment.body.matches('^/test($| [^]*[ ]*$)')
-            overlays:
-              - key: add_pr_body.pull_request_url
-                expression: body.issue.pull_request.url
+        - ref:
+            name: "github"
+            kind: ClusterInterceptor
+            apiVersion: triggers.tekton.dev
+          params:
+            - name: "secretRef"
+              value:
+                secretName: github-secret
+                secretKey: secretToken
+            - name: "eventTypes"
+              value: [ "issue_comment" ]
+        - ref:
+            name: cel
+          params:
+            - name: "filter"
+              value:
+                body.repository.full_name.startsWith('giantswarm/') &&
+                body.repository.name in ['sonobuoy-plugin'] &&
+                'pull_request' in body.issue &&
+                'url' in body.issue.pull_request &&
+                body.issue.state == 'open' &&
+                body.comment.body.matches('^/test($| [^]*[ ]*$)')
+            - name: "overlays"
+              value:
+                - key: add_pr_body.pull_request_url
+                  expression: body.issue.pull_request.url
         - webhook:
             objectRef:
               apiVersion: v1
               kind: Service
               name: add-pr-body
               namespace: tekton-pipelines
-        - cel:
-            overlays:
-              - key: git_clone_depth
-                expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"
+        - ref:
+            name: cel
+          params:
+            - name: "overlays"
+              value:
+                - key: git_clone_depth
+                  expression: "string(body.extensions.add_pr_body.pull_request_body.commits + 1.0)"


### PR DESCRIPTION
Reason:

```
Upgrade "test-infra" failed: failed to create resource: admission webhook "webhook.triggers.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "github"
```

I think it wrong to revert it here: https://github.com/giantswarm/test-infra/pull/212/files#diff-11d931ba23350617bde31b132e9bad1e8d7c7b8973fb34fa1308d0d64ef44a51

Originally added here: https://github.com/giantswarm/test-infra/pull/206/files