### PR TITLE
Remove unnecessary parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove unnecessary parameters from `upgrade-cluster-capi-pure` pipeline.
+
 ## [1.6.1] - 2022-10-18
 
 ### Fixed

--- a/tekton/pipelines/upgrade-cluster-capi-pure.yaml
+++ b/tekton/pipelines/upgrade-cluster-capi-pure.yaml
@@ -52,16 +52,8 @@ spec:
       value: $(params.installation)
     - name: cluster-chart
       value: $(params.cluster-chart)
-    - name: cluster-app-chart-version
-      value: ""
-    - name: cluster-app-catalog
-      value: "cluster"
     - name: default-apps-chart
       value: $(params.default-apps-chart)
-    - name: default-apps-chart-version
-      value: ""
-    - name: default-apps-catalog
-      value: "cluster"
     taskRef:
       name: create-cluster-capi-pure
     workspaces:


### PR DESCRIPTION
Otherwise tekton complains with

```
invalid input params for task create-cluster-capi-pure: didn't need these params but they were provided anyway: [cluster-app-chart-version cluster-app-catalog default-apps-chart-version default-apps-catalog]
```