### PR TITLE
Fix upgrade test

### DIFF
--- a/tekton/pipelines/create-cluster-capi-pure.yaml
+++ b/tekton/pipelines/create-cluster-capi-pure.yaml
@@ -21,6 +21,27 @@ spec:
   - name: default-apps-chart
     type: string
   tasks:
+  - name: calculate-versions
+    params:
+    - name: source-repo-name
+      value: $(params.source-repo-name)
+    - name: provider
+      value: $(params.provider)
+    - name: installation
+      value: $(params.installation)
+    - name: cluster-chart
+      value: $(params.cluster-chart)
+    - name: default-apps-chart
+      value: $(params.default-apps-chart)
+    taskRef:
+      name: calculate-versions
+    workspaces:
+      - name: cluster
+        workspace: cluster
+    resources:
+      inputs:
+        - name: source-repo
+          resource: source-repo
   - name: create-cluster
     params:
     - name: source-repo-name
@@ -33,6 +54,14 @@ spec:
       value: $(params.cluster-chart)
     - name: default-apps-chart
       value: $(params.default-apps-chart)
+    - name: cluster-app-chart-version
+      value: $(tasks.calculate-versions.results.cluster-app-chart-version)
+    - name: cluster-app-catalog
+      value: $(tasks.calculate-versions.results.cluster-app-catalog)
+    - name: default-apps-chart-version
+      value: $(tasks.calculate-versions.results.default-apps-chart-version)
+    - name: default-apps-catalog
+      value: $(tasks.calculate-versions.results.default-apps-catalog)
     taskRef:
       name: create-cluster-capi-pure
     workspaces:

--- a/tekton/pipelines/upgrade-cluster-capi-pure.yaml
+++ b/tekton/pipelines/upgrade-cluster-capi-pure.yaml
@@ -52,8 +52,16 @@ spec:
       value: $(params.installation)
     - name: cluster-chart
       value: $(params.cluster-chart)
+    - name: cluster-app-chart-version
+      value: ""
+    - name: cluster-app-catalog
+      value: "cluster"
     - name: default-apps-chart
       value: $(params.default-apps-chart)
+    - name: default-apps-chart-version
+      value: ""
+    - name: default-apps-catalog
+      value: "cluster"
     taskRef:
       name: create-cluster-capi-pure
     workspaces:

--- a/tekton/tasks/cleanup-capi-pure.yaml
+++ b/tekton/tasks/cleanup-capi-pure.yaml
@@ -20,7 +20,7 @@ spec:
     description: Organization that owns the cluster
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/kubectl-gs:2.25.0
+    image: quay.io/giantswarm/kubectl-gs:2.27.0
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/create-cluster-capi-pure.yaml
+++ b/tekton/tasks/create-cluster-capi-pure.yaml
@@ -13,7 +13,15 @@ spec:
     type: string
   - name: cluster-chart
     type: string
+  - name: cluster-app-chart-version
+    type: string
+  - name: cluster-app-catalog
+    type: string
   - name: default-apps-chart
+    type: string
+  - name: default-apps-chart-version
+    type: string
+  - name: default-apps-catalog
     type: string
   volumes:
   - name: kubeconfig
@@ -32,52 +40,15 @@ spec:
   - name: organization
     description: Organization that owns the cluster.
   steps:
-  - name: chown-source-repo
-    command:
-    - chown
-    - -R
-    - 1000:1000
-    - /workspace/source-repo
-    image: quay.io/giantswarm/standup:3.2.0
-    securityContext:
-      runAsUser: 0
-      runAsGroup: 0
-  - name: calculate-inputs
-    image: quay.io/giantswarm/standup:3.2.0
-    env:
-    - name: SOURCE_REPO_NAME
-      value: $(params.source-repo-name)
-    - name: INSTALLATION
-      value: $(params.installation)
-    - name: CLUSTER_CHART
-      value: $(params.cluster-chart)
-    - name: DEFAULT_APPS_CHART
-      value: $(params.default-apps-chart)
-    script: |
-      #! /bin/sh
-
-      set -e
-      set -x
-
-      cd /workspace/source-repo
-      git fetch --unshallow
-      parent_tag=$(git describe --tags --abbrev=0 | sed -e "s/^v//")
-      hash=$(git describe --always --abbrev=0)
-      repo_version=${parent_tag}-${hash}
-
-      if [ "$SOURCE_REPO_NAME" = "$DEFAULT_APPS_CHART" ]; then
-        app_flags="--default-apps-catalog cluster-test --default-apps-version $repo_version"
-      else
-        app_flags="--cluster-catalog cluster-test --cluster-version $repo_version"
-      fi
-
-      echo $app_flags > $(workspaces.cluster.path)/kubectl-gs-flags
-
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.25.0
+    image: quay.io/giantswarm/kubectl-gs:2.27.0
     env:
     - name: PROVIDER
       value: $(params.provider)
+    - name: CLUSTER_APP_CHART_VERSION
+      value: $(params.cluster-app-chart-version)
+    - name: DEFAULT_APPS_CHART_VERSION
+      value: $(params.default-apps-chart-version)
     volumeMounts:
     - name: kubeconfig
       mountPath: /etc/kubeconfig
@@ -88,9 +59,15 @@ spec:
       set -x
 
       export KUBECONFIG=/etc/kubeconfig/$PROVIDER
-      cluster_id="t$(date +%s | cut -c7-10)"
+      cluster_id="t$(date +%s | cut -c7-10)${RANDOM}"
       organization=giantswarm
-      extra_flags=$(cat $(workspaces.cluster.path)/kubectl-gs-flags)
+      extra_flags=""
+      if [ ! -z "$CLUSTER_APP_CHART_VERSION" ]; then
+        extra_flags="${extra_flags} --cluster-catalog cluster-test --cluster-version $CLUSTER_APP_CHART_VERSION"
+      fi
+      if [ ! -z "$DEFAULT_APPS_CHART_VERSION" ]; then
+        extra_flags="${extra_flags} --default-apps-catalog cluster-test --default-apps-version $DEFAULT_APPS_CHART_VERSION"
+      fi
 
       echo "generating template for cluster $cluster_id"
 

--- a/tekton/tasks/upgrade-cluster-capi-pure.yaml
+++ b/tekton/tasks/upgrade-cluster-capi-pure.yaml
@@ -43,5 +43,7 @@ spec:
       while [ `kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o json | jq -r '.status.version'` != "$(params.cluster-app-chart-version)" ] || [ `kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o json | jq -r '.status.release.status'` != "deployed" ]
       do
         echo "$(date): App for cluster '$(params.cluster-id)' still uses old version or has failed"
+        echo "$(date): Version: $(kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o jsonpath='{.status.version}')"
+        echo "$(date): Status: $(kubectl --kubeconfig /etc/kubeconfig/$(params.provider) get apps -n org-$(params.organization) $(params.cluster-id) -o jsonpath='{.status.release.status}')"
         sleep 10
       done


### PR DESCRIPTION
After all the rollbacks of test-infra, we broke the upgrade test and it was just using the last version of the app rather than upgrading to it.