### PR TITLE
Update: Bump kubectl-gs to 2.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update kubectl-gs to v2.32.0 which uses objects for `CAPA` machine pools instead of arrays
+
 ## [1.12.0] - 2023-01-12
 
 ### Changed

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -23,7 +23,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.29.5
+    image: quay.io/giantswarm/kubectl-gs:2.32.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster-capi-pure.yaml
+++ b/tekton/tasks/create-cluster-capi-pure.yaml
@@ -41,7 +41,7 @@ spec:
     description: Organization that owns the cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.29.5
+    image: quay.io/giantswarm/kubectl-gs:2.32.0
     env:
     - name: PROVIDER
       value: $(params.provider)


### PR DESCRIPTION
Updates kubectl-gs to v2.32.0 which uses objects for `CAPA` machine pools instead of arrays.

Part of - https://github.com/giantswarm/roadmap/issues/1614