### PR TITLE
Bump `kubectl-gs` to `v2.37.0`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `kubectl-gs` to `v2.37.0`.
+
 ## [1.17.0] - 2023-05-16
 
 ### Changed

--- a/tekton/tasks/cleanup-capi-pure.yaml
+++ b/tekton/tasks/cleanup-capi-pure.yaml
@@ -20,7 +20,7 @@ spec:
     description: Organization that owns the cluster
   steps:
   - name: cleanup
-    image: quay.io/giantswarm/kubectl-gs:2.34.0
+    image: quay.io/giantswarm/kubectl-gs:2.37.0
     volumeMounts:
       - name: kubeconfig
         mountPath: /etc/kubeconfig

--- a/tekton/tasks/create-cluster-capi-hybrid.yaml
+++ b/tekton/tasks/create-cluster-capi-hybrid.yaml
@@ -23,7 +23,7 @@ spec:
     description: The ID of the created cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.34.0
+    image: quay.io/giantswarm/kubectl-gs:2.37.0
     volumeMounts:
       - name: endpoints-config
         mountPath: /etc/endpoints-config

--- a/tekton/tasks/create-cluster-capi-pure.yaml
+++ b/tekton/tasks/create-cluster-capi-pure.yaml
@@ -41,7 +41,7 @@ spec:
     description: Organization that owns the cluster.
   steps:
   - name: create-cluster
-    image: quay.io/giantswarm/kubectl-gs:2.34.0
+    image: quay.io/giantswarm/kubectl-gs:2.37.0
     env:
     - name: PROVIDER
       value: $(params.provider)


### PR DESCRIPTION
this should at least partially fix e2e errors on vintage