### PR TITLE
Raise `wait-for-ready` timeout to 2h to leave broken apps enough time…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Raise `wait-for-ready` timeout to 2h to leave broken apps enough time to install.
+
 ## [1.25.0] - 2023-08-29
 
 ### Added

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -67,7 +67,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: h0m0s
+    timeout: 2h0m0s
     taskRef:
       name: wait-for-ready
     params:

--- a/tekton/pipelines/cis.yaml
+++ b/tekton/pipelines/cis.yaml
@@ -67,7 +67,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 1h0m0s
+    timeout: h0m0s
     taskRef:
       name: wait-for-ready
     params:

--- a/tekton/pipelines/cncf.yaml
+++ b/tekton/pipelines/cncf.yaml
@@ -73,7 +73,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 1h0m0s
+    timeout: 2h0m0s
     taskRef:
       name: wait-for-ready
     params:

--- a/tekton/pipelines/e2e.yaml
+++ b/tekton/pipelines/e2e.yaml
@@ -73,7 +73,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 1h0m0s
+    timeout: 2h0m0s
     taskRef:
       name: wait-for-ready
     params:

--- a/tekton/pipelines/upgrade.yaml
+++ b/tekton/pipelines/upgrade.yaml
@@ -78,7 +78,7 @@ spec:
 
   - name: wait-for-ready
     runAfter: [create-cluster]
-    timeout: 1h30m0s
+    timeout: 2h00m0s
     taskRef:
       name: wait-for-ready
     params:


### PR DESCRIPTION
… to install.