### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
+
 ## [1.46.1] - 2024-04-29
 
 ### Fixed

--- a/tekton/kyverno-policy-exception.yaml
+++ b/tekton/kyverno-policy-exception.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: test-infra

--- a/tekton/triggers/el-github-listener-interceptor-policy-exception.yaml
+++ b/tekton/triggers/el-github-listener-interceptor-policy-exception.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: el-github-listener-interceptor-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.